### PR TITLE
Feat/bulk import

### DIFF
--- a/src/__tests__/DocFetchService.test.ts
+++ b/src/__tests__/DocFetchService.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { DocFetchService } from '../services/DocFetchService';
+
+describe('DocFetchService guard helpers', () => {
+    it('returns trimmed editor textarea content when present', () => {
+        const doc = new DOMParser().parseFromString(
+            '<textarea name="bio">  Existing content  </textarea>',
+            'text/html'
+        );
+
+        expect(DocFetchService._getEditorContentForGuard(doc)).toBe('Existing content');
+    });
+
+    it('returns null when the editor textarea is missing', () => {
+        const doc = new DOMParser().parseFromString('<div>No editor</div>', 'text/html');
+
+        expect(DocFetchService._getEditorContentForGuard(doc)).toBeNull();
+    });
+});

--- a/src/__tests__/DocFetchService.test.ts
+++ b/src/__tests__/DocFetchService.test.ts
@@ -11,6 +11,15 @@ describe('DocFetchService guard helpers', () => {
         expect(DocFetchService._getEditorContentForGuard(doc)).toBe('Existing content');
     });
 
+    it('supports the webcontent editor textarea variant', () => {
+        const doc = new DOMParser().parseFromString(
+            '<textarea name="webcontent">  Replacement target  </textarea>',
+            'text/html'
+        );
+
+        expect(DocFetchService._getEditorContentForGuard(doc)).toBe('Replacement target');
+    });
+
     it('returns null when the editor textarea is missing', () => {
         const doc = new DOMParser().parseFromString('<div>No editor</div>', 'text/html');
 

--- a/src/__tests__/DocManager.test.ts
+++ b/src/__tests__/DocManager.test.ts
@@ -166,8 +166,29 @@ describe('DocManager bulk import planner', () => {
         const plan = DocManager._buildBulkImportPlan(files, items);
 
         expect(plan.matchedCount).toBe(0);
-        expect(plan.missingCount).toBe(1);
+        expect(plan.missingCount).toBe(0);
         expect(plan.ignoredFiles).toEqual(['Import/Nested/A0.md', 'Import/notes.txt']);
+    });
+
+    it('shows selected Markdown files with no DocManager match as missing', () => {
+        const items = [makeItem('A0', '101')];
+        const files = [
+            makeFile('A0.md', 'Import/A0.md'),
+            makeFile('Missing.md', 'Import/Missing.md'),
+        ];
+
+        const plan = DocManager._buildBulkImportPlan(files, items);
+
+        expect(plan.matchedCount).toBe(1);
+        expect(plan.missingCount).toBe(1);
+        expect(plan.rows.map(row => row.status)).toEqual(['matched', 'missing']);
+        expect(plan.rows[1]).toMatchObject({
+            docId: '',
+            docName: 'Missing',
+            expectedFileName: 'Missing.md',
+            status: 'missing',
+        });
+        expect(plan.fileByDocId.get('101')?.name).toBe('A0.md');
     });
 
     it('blocks duplicate Markdown filenames', () => {

--- a/src/__tests__/DocManager.test.ts
+++ b/src/__tests__/DocManager.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { DocManager } from '../modules/DocManager';
+import type { IBulkItem } from '../interfaces/IBulkOperationConfig';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -18,6 +19,25 @@ function makeBtn(): HTMLButtonElement {
 
 function cleanupDOM(): void {
     document.body.innerHTML = '';
+    document.head.innerHTML = '';
+}
+
+function makeItem(docName: string, docId: string): IBulkItem {
+    return {
+        docId,
+        docName,
+        title: docName,
+        row: document.createElement('tr') as HTMLTableRowElement,
+    };
+}
+
+function makeFile(name: string, relativePath: string, content: string = '# Title'): File {
+    const file = new File([content], name, { type: 'text/markdown' });
+    Object.defineProperty(file, 'webkitRelativePath', {
+        value: relativePath,
+        configurable: true,
+    });
+    return file;
 }
 
 // ─── Module smoke test ──────────────────────────────────────────────────────
@@ -93,5 +113,129 @@ describe('DocManager bulk operation button reference', () => {
         };
 
         expect(() => buggyOnFinalize()).toThrow();
+    });
+});
+
+describe('DocManager bulk import planner', () => {
+    beforeEach(() => {
+        cleanupDOM();
+    });
+
+    it('matches files by exact DocManager name plus .md', () => {
+        const items = [
+            makeItem('A0', '101'),
+            makeItem('A0.md', '102'),
+        ];
+        const files = [
+            makeFile('A0.md', 'Import/A0.md'),
+            makeFile('A0.md.md', 'Import/A0.md.md'),
+        ];
+
+        const plan = DocManager._buildBulkImportPlan(files, items);
+
+        expect(plan.matchedCount).toBe(2);
+        expect(plan.missingCount).toBe(0);
+        expect(plan.hasBlockingErrors).toBe(false);
+        expect(plan.fileByDocId.get('101')?.name).toBe('A0.md');
+        expect(plan.fileByDocId.get('102')?.name).toBe('A0.md.md');
+    });
+
+    it('blocks HTML and DOCX files in the selected directory', () => {
+        const items = [makeItem('A0', '101')];
+        const files = [
+            makeFile('A0.md', 'Import/A0.md'),
+            makeFile('A0.html', 'Import/A0.html'),
+            makeFile('A0.htm', 'Import/A0.htm'),
+            makeFile('A1.docx', 'Import/A1.docx'),
+        ];
+
+        const plan = DocManager._buildBulkImportPlan(files, items);
+
+        expect(plan.matchedCount).toBe(1);
+        expect(plan.hasBlockingErrors).toBe(true);
+        expect(plan.blockedFiles).toEqual(['Import/A0.html', 'Import/A0.htm', 'Import/A1.docx']);
+    });
+
+    it('ignores unrelated files and nested Markdown files', () => {
+        const items = [makeItem('A0', '101')];
+        const files = [
+            makeFile('A0.md', 'Import/Nested/A0.md'),
+            makeFile('notes.txt', 'Import/notes.txt'),
+        ];
+
+        const plan = DocManager._buildBulkImportPlan(files, items);
+
+        expect(plan.matchedCount).toBe(0);
+        expect(plan.missingCount).toBe(1);
+        expect(plan.ignoredFiles).toEqual(['Import/Nested/A0.md', 'Import/notes.txt']);
+    });
+
+    it('blocks duplicate Markdown filenames', () => {
+        const items = [makeItem('A0', '101')];
+        const files = [
+            makeFile('A0.md', 'ImportA/A0.md'),
+            makeFile('A0.md', 'ImportB/A0.md'),
+        ];
+
+        const plan = DocManager._buildBulkImportPlan(files, items);
+
+        expect(plan.hasBlockingErrors).toBe(true);
+        expect(plan.duplicateFileNames).toEqual(['A0.md']);
+        expect(plan.rows[0].status).toBe('duplicate');
+        expect(plan.fileByDocId.has('101')).toBe(false);
+    });
+});
+
+describe('DocManager bulk import conversion', () => {
+    it('converts Markdown to sanitized HTML', () => {
+        const html = DocManager._markdownToImportHtml(
+            '# Heading\n\n<script>alert(1)</script>\n\n**Bold**'
+        );
+
+        expect(html).toContain('<h1>Heading</h1>');
+        expect(html).toContain('<strong>Bold</strong>');
+        expect(html).not.toContain('<script>');
+    });
+
+    it('strips event attributes and dangerous URLs from imported HTML', () => {
+        const html = DocManager._sanitizeImportHtml(
+            '<p onclick="alert(1)">Text</p><a href="javascript:alert(1)">Bad</a>'
+        );
+
+        expect(html).toContain('<p>Text</p>');
+        expect(html).toContain('<a>Bad</a>');
+        expect(html).not.toContain('onclick');
+        expect(html).not.toContain('javascript:');
+    });
+});
+
+describe('DocManager advanced drawer', () => {
+    beforeEach(() => {
+        cleanupDOM();
+        vi.restoreAllMocks();
+    });
+
+    it('opens a native advanced routines modal with all bulk actions', () => {
+        DocManager.injectAdvancedDrawer();
+
+        document.querySelector<HTMLButtonElement>('#ffne-docmanager-advanced-drawer button')?.click();
+
+        expect(document.getElementById('ffne-docmanager-advanced-modal')).not.toBeNull();
+        expect(document.querySelector('[data-ffne-action="bulk-export"]')).not.toBeNull();
+        expect(document.querySelector('[data-ffne-action="bulk-refresh"]')).not.toBeNull();
+        expect(document.querySelector('[data-ffne-action="bulk-import"]')).not.toBeNull();
+    });
+
+    it('routes Bulk Export and Bulk Refresh through existing handlers', () => {
+        const exportSpy = vi.spyOn(DocManager, 'runBulkExport').mockResolvedValue(undefined);
+        const refreshSpy = vi.spyOn(DocManager, 'runBulkRefresh').mockResolvedValue(undefined);
+
+        DocManager.injectAdvancedDrawer();
+        document.querySelector<HTMLButtonElement>('#ffne-docmanager-advanced-drawer button')?.click();
+        document.querySelector<HTMLButtonElement>('[data-ffne-action="bulk-export"]')?.click();
+        document.querySelector<HTMLButtonElement>('[data-ffne-action="bulk-refresh"]')?.click();
+
+        expect(exportSpy).toHaveBeenCalledTimes(1);
+        expect(refreshSpy).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/__tests__/DocManager.test.ts
+++ b/src/__tests__/DocManager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { DocManager } from '../modules/DocManager';
 import type { IBulkItem } from '../interfaces/IBulkOperationConfig';
 
@@ -35,6 +35,15 @@ function makeFile(name: string, relativePath: string, content: string = '# Title
     const file = new File([content], name, { type: 'text/markdown' });
     Object.defineProperty(file, 'webkitRelativePath', {
         value: relativePath,
+        configurable: true,
+    });
+    return file;
+}
+
+function makeSelectedFile(name: string, content: string = '# Title'): File {
+    const file = new File([content], name, { type: 'text/markdown' });
+    Object.defineProperty(file, 'webkitRelativePath', {
+        value: '',
         configurable: true,
     });
     return file;
@@ -191,6 +200,22 @@ describe('DocManager bulk import planner', () => {
         expect(plan.fileByDocId.get('101')?.name).toBe('A0.md');
     });
 
+    it('matches individually selected files without directory paths', () => {
+        const items = [makeItem('A0', '101')];
+        const files = [
+            makeSelectedFile('A0.md'),
+            makeSelectedFile('Missing.md'),
+        ];
+
+        const plan = DocManager._buildBulkImportPlan(files, items);
+
+        expect(plan.matchedCount).toBe(1);
+        expect(plan.missingCount).toBe(1);
+        expect(plan.ignoredFiles).toEqual([]);
+        expect(plan.rows.map(row => row.expectedFileName)).toEqual(['A0.md', 'Missing.md']);
+        expect(plan.fileByDocId.get('101')?.name).toBe('A0.md');
+    });
+
     it('blocks duplicate Markdown filenames', () => {
         const items = [makeItem('A0', '101')];
         const files = [
@@ -204,6 +229,35 @@ describe('DocManager bulk import planner', () => {
         expect(plan.duplicateFileNames).toEqual(['A0.md']);
         expect(plan.rows[0].status).toBe('duplicate');
         expect(plan.fileByDocId.has('101')).toBe(false);
+    });
+});
+
+describe('DocManager bulk import modal', () => {
+    beforeEach(() => {
+        cleanupDOM();
+    });
+
+    afterEach(() => {
+        DocManager.closeBulkImportModal();
+        cleanupDOM();
+    });
+
+    it('offers separate folder and file pickers', () => {
+        DocManager.openBulkImportModal();
+
+        const folderButton = document.getElementById('ffne-dm-browse-folder');
+        const filesButton = document.getElementById('ffne-dm-browse-files');
+        const folderInput = document.getElementById('ffne-dm-import-folder-input') as HTMLInputElement | null;
+        const filesInput = document.getElementById('ffne-dm-import-files-input') as HTMLInputElement | null;
+
+        expect(folderButton?.textContent).toBe('Browse Folder');
+        expect(filesButton?.textContent).toBe('Browse Files');
+        expect(folderInput?.type).toBe('file');
+        expect(folderInput?.multiple).toBe(true);
+        expect(folderInput?.hasAttribute('webkitdirectory')).toBe(true);
+        expect(filesInput?.type).toBe('file');
+        expect(filesInput?.multiple).toBe(true);
+        expect(filesInput?.hasAttribute('webkitdirectory')).toBe(false);
     });
 });
 

--- a/src/__tests__/DocManager.test.ts
+++ b/src/__tests__/DocManager.test.ts
@@ -249,6 +249,7 @@ describe('DocManager bulk import modal', () => {
         const filesButton = document.getElementById('ffne-dm-browse-files');
         const folderInput = document.getElementById('ffne-dm-import-folder-input') as HTMLInputElement | null;
         const filesInput = document.getElementById('ffne-dm-import-files-input') as HTMLInputElement | null;
+        const results = document.getElementById('ffne-dm-import-results') as HTMLElement | null;
 
         expect(folderButton?.textContent).toBe('Browse Folder');
         expect(filesButton?.textContent).toBe('Browse Files');
@@ -258,6 +259,7 @@ describe('DocManager bulk import modal', () => {
         expect(filesInput?.type).toBe('file');
         expect(filesInput?.multiple).toBe(true);
         expect(filesInput?.hasAttribute('webkitdirectory')).toBe(false);
+        expect(results?.hidden).toBe(true);
     });
 });
 

--- a/src/__tests__/DocManager.test.ts
+++ b/src/__tests__/DocManager.test.ts
@@ -295,7 +295,14 @@ describe('DocManager advanced drawer', () => {
     it('opens a native advanced routines modal with all bulk actions', () => {
         DocManager.injectAdvancedDrawer();
 
-        document.querySelector<HTMLButtonElement>('#ffne-docmanager-advanced-drawer button')?.click();
+        const drawerButton = document.querySelector<HTMLButtonElement>('#ffne-docmanager-advanced-drawer button');
+        expect(drawerButton?.classList.contains('ffne-dm-drawer-pull')).toBe(true);
+        expect(drawerButton?.getAttribute('aria-label')).toBe('Open advanced document routines');
+        expect(drawerButton?.textContent?.trim()).toBe('');
+        expect(drawerButton?.querySelector('.ffne-dm-drawer-grabber')).not.toBeNull();
+        expect(drawerButton?.querySelector('.ffne-dm-drawer-chevron')).not.toBeNull();
+
+        drawerButton?.click();
 
         expect(document.getElementById('ffne-docmanager-advanced-modal')).not.toBeNull();
         expect(document.querySelector('[data-ffne-action="bulk-export"]')).not.toBeNull();

--- a/src/delegates/GlobalDelegate.ts
+++ b/src/delegates/GlobalDelegate.ts
@@ -25,9 +25,9 @@ export const GlobalDelegate: IDelegate = {
                     doc.querySelector('#content_wrapper')) as HTMLElement;
             case Elements.EDITOR_TEXT_AREA:
                 // Used globally for all docs that have editable textareas (usually author-accessible pages only)
-                return doc.querySelector("textarea[name='bio']") as HTMLElement;
+                return doc.querySelector("textarea[name='bio'], textarea#bio, textarea[name='webcontent'], textarea#webcontent") as HTMLElement;
             case Elements.EDITOR_TEXT_AREA_IFRAME:
-                return doc.querySelector("#bio_ifr") as HTMLElement;
+                return doc.querySelector("#bio_ifr, #webcontent_ifr") as HTMLElement;
             case Elements.SAVE_BUTTON:
                 return doc.querySelector("button[type='submit']") as HTMLButtonElement;
             case Elements.SUCCESS_PANEL:

--- a/src/interfaces/IBulkOperationConfig.ts
+++ b/src/interfaces/IBulkOperationConfig.ts
@@ -9,6 +9,7 @@ export interface IBulkOperationConfig {
     verb: string;
     filterRows?: (items: IBulkItem[]) => IBulkItem[];
     processItem: (item: IBulkItem) => Promise<boolean>;
+    onItemStart?: (item: IBulkItem, pass: 1 | 2, index: number, total: number) => void;
     onItemSuccess?: (item: IBulkItem, pass: 1 | 2) => void;
     onPermanentFailure?: (item: IBulkItem) => void;
     preBatch?: (totalCount: number) => void;

--- a/src/interfaces/IBulkOperationConfig.ts
+++ b/src/interfaces/IBulkOperationConfig.ts
@@ -1,6 +1,7 @@
 // === Shared bulk operation types and helper ===
 export interface IBulkItem {
     docId: string;
+    docName: string;
     title: string;
     row: HTMLTableRowElement;
 }

--- a/src/modules/DocManager.ts
+++ b/src/modules/DocManager.ts
@@ -583,9 +583,17 @@ export const DocManager = {
                 margin-bottom: 10px;
             }
             .ffne-dm-file-input {
-                font-family: Verdana, Arial, sans-serif;
-                font-size: 12px;
-                max-width: 100%;
+                display: none;
+            }
+            .ffne-dm-picker-group {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                flex-wrap: wrap;
+            }
+            .ffne-dm-selection-label {
+                color: #555;
+                font-size: 11px;
             }
             .ffne-dm-summary {
                 margin: 8px 0;
@@ -725,10 +733,16 @@ export const DocManager = {
                 </div>
                 <div class="ffne-dm-modal-body">
                     <div class="ffne-dm-import-controls">
-                        <input id="ffne-dm-import-input" class="ffne-dm-file-input" type="file" accept=".md,text/markdown" webkitdirectory multiple>
+                        <div class="ffne-dm-picker-group">
+                            <button type="button" id="ffne-dm-browse-folder" class="ffne-dm-btn">Browse Folder</button>
+                            <button type="button" id="ffne-dm-browse-files" class="ffne-dm-btn">Browse Files</button>
+                            <span id="ffne-dm-import-selection" class="ffne-dm-selection-label">No files selected.</span>
+                            <input id="ffne-dm-import-folder-input" class="ffne-dm-file-input" type="file" accept=".md,text/markdown" webkitdirectory multiple>
+                            <input id="ffne-dm-import-files-input" class="ffne-dm-file-input" type="file" accept=".md,text/markdown" multiple>
+                        </div>
                         <button type="button" id="ffne-dm-import-start" class="ffne-dm-btn" disabled>Import</button>
                     </div>
-                    <div id="ffne-dm-import-preview" class="ffne-dm-summary">Select a folder containing Markdown files.</div>
+                    <div id="ffne-dm-import-preview" class="ffne-dm-summary">Select a folder or Markdown files.</div>
                     <div class="ffne-dm-footer">
                         <span id="ffne-dm-import-status" class="ffne-dm-run-status"></span>
                         <button type="button" class="ffne-dm-btn" data-ffne-action="close-import">Close</button>
@@ -737,19 +751,49 @@ export const DocManager = {
             </div>
         `;
 
-        const input = overlay.querySelector<HTMLInputElement>('#ffne-dm-import-input');
+        const folderButton = overlay.querySelector<HTMLButtonElement>('#ffne-dm-browse-folder');
+        const filesButton = overlay.querySelector<HTMLButtonElement>('#ffne-dm-browse-files');
+        const folderInput = overlay.querySelector<HTMLInputElement>('#ffne-dm-import-folder-input');
+        const filesInput = overlay.querySelector<HTMLInputElement>('#ffne-dm-import-files-input');
         const startButton = overlay.querySelector<HTMLButtonElement>('#ffne-dm-import-start');
         const preview = overlay.querySelector<HTMLElement>('#ffne-dm-import-preview');
         const status = overlay.querySelector<HTMLElement>('#ffne-dm-import-status');
+        const selection = overlay.querySelector<HTMLElement>('#ffne-dm-import-selection');
 
-        input?.addEventListener('change', () => {
+        const updateSelectedFiles = (input: HTMLInputElement, sourceLabel: string) => {
             const files = Array.from(input.files || []);
             const plan = _buildBulkImportPlan(files);
             this._bulkImportPlan = plan;
             if (preview && startButton) {
                 this._renderBulkImportPreview(preview, startButton, plan);
             }
+            if (selection) {
+                const count = files.length;
+                selection.textContent = count === 1
+                    ? `${sourceLabel}: 1 file selected.`
+                    : `${sourceLabel}: ${count} files selected.`;
+            }
             if (status) status.textContent = '';
+        };
+
+        folderButton?.addEventListener('click', () => {
+            if (!folderInput) return;
+            folderInput.value = '';
+            folderInput.click();
+        });
+
+        filesButton?.addEventListener('click', () => {
+            if (!filesInput) return;
+            filesInput.value = '';
+            filesInput.click();
+        });
+
+        folderInput?.addEventListener('change', () => {
+            updateSelectedFiles(folderInput, 'Folder');
+        });
+
+        filesInput?.addEventListener('change', () => {
+            updateSelectedFiles(filesInput, 'Files');
         });
 
         startButton?.addEventListener('click', async (e) => {

--- a/src/modules/DocManager.ts
+++ b/src/modules/DocManager.ts
@@ -115,6 +115,11 @@ function _buildBulkImportPlan(files: File[], items: IBulkItem[] = _collectBulkIt
     const markdownFilesByName = new Map<string, File[]>();
     const blockedFiles: string[] = [];
     const ignoredFiles: string[] = [];
+    const itemByExpectedFileName = new Map<string, IBulkItem>();
+
+    for (const item of items) {
+        itemByExpectedFileName.set(`${item.docName}${MARKDOWN_EXTENSION}`, item);
+    }
 
     for (const file of files) {
         const displayPath = _getFileDisplayPath(file);
@@ -147,26 +152,26 @@ function _buildBulkImportPlan(files: File[], items: IBulkItem[] = _collectBulkIt
     let matchedCount = 0;
     let missingCount = 0;
 
-    for (const item of items) {
-        const expectedFileName = `${item.docName}${MARKDOWN_EXTENSION}`;
-        const matchedFiles = markdownFilesByName.get(expectedFileName) || [];
+    for (const [fileName, matchedFiles] of markdownFilesByName) {
+        const item = itemByExpectedFileName.get(fileName);
+        const targetDocName = fileName.slice(0, -MARKDOWN_EXTENSION.length);
 
-        if (duplicateSet.has(expectedFileName)) {
+        if (duplicateSet.has(fileName)) {
             rows.push({
-                docId: item.docId,
-                docName: item.docName,
-                expectedFileName,
+                docId: item?.docId || '',
+                docName: item?.docName || targetDocName,
+                expectedFileName: fileName,
                 status: 'duplicate',
                 file: null,
             });
             continue;
         }
 
-        if (matchedFiles.length === 1) {
+        if (item && matchedFiles.length === 1) {
             rows.push({
                 docId: item.docId,
                 docName: item.docName,
-                expectedFileName,
+                expectedFileName: fileName,
                 status: 'matched',
                 file: matchedFiles[0],
             });
@@ -176,11 +181,11 @@ function _buildBulkImportPlan(files: File[], items: IBulkItem[] = _collectBulkIt
         }
 
         rows.push({
-            docId: item.docId,
-            docName: item.docName,
-            expectedFileName,
+            docId: '',
+            docName: targetDocName,
+            expectedFileName: fileName,
             status: 'missing',
-            file: null,
+            file: matchedFiles[0] || null,
         });
         missingCount++;
     }
@@ -825,7 +830,7 @@ export const DocManager = {
         preview.innerHTML = `
             <div>
                 <strong>${plan.matchedCount}</strong> matched,
-                <strong>${plan.missingCount}</strong> missing,
+                <strong>${plan.missingCount}</strong> missing in DocManager,
                 <strong>${plan.duplicateFileNames.length}</strong> duplicate,
                 <strong>${plan.ignoredFiles.length}</strong> ignored.
             </div>
@@ -836,11 +841,11 @@ export const DocManager = {
                 <thead>
                     <tr>
                         <th>DocManager Name</th>
-                        <th>Expected File</th>
+                        <th>Selected File</th>
                         <th>Status</th>
                     </tr>
                 </thead>
-                <tbody>${rowsHtml || '<tr><td colspan="3">No documents found.</td></tr>'}</tbody>
+                <tbody>${rowsHtml || '<tr><td colspan="3">No top-level Markdown files found.</td></tr>'}</tbody>
             </table>
         `;
     },

--- a/src/modules/DocManager.ts
+++ b/src/modules/DocManager.ts
@@ -12,6 +12,232 @@ import { DocIframeHandler } from './DocIframeHandler';
 import { IBulkOperationConfig, IBulkItem } from '../interfaces/IBulkOperationConfig';
 import { applyExportTransforms } from '../utils/exportTransform';
 import { writeToClipboard } from '../utils/clipboard';
+import { SimpleMarkdownParser } from './SimpleMarkdownParser';
+
+const ADVANCED_DRAWER_ID = 'ffne-docmanager-advanced-drawer';
+const ADVANCED_MODAL_ID = 'ffne-docmanager-advanced-modal';
+const IMPORT_MODAL_ID = 'ffne-docmanager-import-modal';
+const ADVANCED_STYLE_ID = 'ffne-docmanager-advanced-styles';
+const MARKDOWN_EXTENSION = '.md';
+const BLOCKED_IMPORT_EXTENSIONS = new Set(['.htm', '.html', '.docx']);
+
+type BulkImportRowStatus = 'matched' | 'missing' | 'duplicate';
+
+interface BulkImportPreviewRow {
+    docId: string;
+    docName: string;
+    expectedFileName: string;
+    status: BulkImportRowStatus;
+    file: File | null;
+}
+
+interface BulkImportPlan {
+    totalFiles: number;
+    totalDocs: number;
+    matchedCount: number;
+    missingCount: number;
+    duplicateFileNames: string[];
+    blockedFiles: string[];
+    ignoredFiles: string[];
+    rows: BulkImportPreviewRow[];
+    fileByDocId: Map<string, File>;
+    hasBlockingErrors: boolean;
+}
+
+function _sanitizeDocTitle(title: string): string {
+    return title.trim().replace(/[/\\?%*:|"<>]/g, '-');
+}
+
+function _getCellText(cell: HTMLTableCellElement | undefined): string {
+    if (!cell) return '';
+    return (cell.innerText || cell.textContent || '').trim();
+}
+
+function _collectBulkItems(): IBulkItem[] {
+    const allRows = Core.getElements(Elements.DOC_TABLE_BODY_ROWS);
+    const items: IBulkItem[] = [];
+
+    for (const row of allRows) {
+        const tableRow = row as HTMLTableRowElement;
+        const editLink = row.querySelector('a[href*="docid="]') as HTMLAnchorElement;
+        if (!editLink) continue;
+
+        const match = editLink.href.match(/docid=(\d+)/);
+        if (!match) continue;
+
+        const docName = _getCellText(tableRow.cells[1]);
+        if (!docName) continue;
+
+        items.push({
+            docId: match[1],
+            docName,
+            title: _sanitizeDocTitle(docName),
+            row: tableRow,
+        });
+    }
+
+    return items;
+}
+
+function _getFileDisplayPath(file: File): string {
+    const withPath = file as File & { webkitRelativePath?: string };
+    return withPath.webkitRelativePath || file.name;
+}
+
+function _getPathFileName(path: string): string {
+    const parts = path.split(/[\\/]+/).filter(Boolean);
+    return parts.length > 0 ? parts[parts.length - 1] : path;
+}
+
+function _getTopLevelFileName(file: File): string | null {
+    const path = _getFileDisplayPath(file);
+    const parts = path.split(/[\\/]+/).filter(Boolean);
+    if (parts.length === 0) return null;
+    if (parts.length > 2) return null;
+    return parts[parts.length - 1];
+}
+
+function _getLowerExtension(fileName: string): string {
+    const idx = fileName.lastIndexOf('.');
+    return idx >= 0 ? fileName.slice(idx).toLowerCase() : '';
+}
+
+function _escapeHtml(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function _buildBulkImportPlan(files: File[], items: IBulkItem[] = _collectBulkItems()): BulkImportPlan {
+    const markdownFilesByName = new Map<string, File[]>();
+    const blockedFiles: string[] = [];
+    const ignoredFiles: string[] = [];
+
+    for (const file of files) {
+        const displayPath = _getFileDisplayPath(file);
+        const fileName = _getPathFileName(displayPath);
+        const extension = _getLowerExtension(fileName);
+
+        if (BLOCKED_IMPORT_EXTENSIONS.has(extension)) {
+            blockedFiles.push(displayPath);
+            continue;
+        }
+
+        const topLevelFileName = _getTopLevelFileName(file);
+        if (!topLevelFileName || extension !== MARKDOWN_EXTENSION) {
+            ignoredFiles.push(displayPath);
+            continue;
+        }
+
+        const existing = markdownFilesByName.get(topLevelFileName) || [];
+        existing.push(file);
+        markdownFilesByName.set(topLevelFileName, existing);
+    }
+
+    const duplicateFileNames = Array.from(markdownFilesByName.entries())
+        .filter(([, matchedFiles]) => matchedFiles.length > 1)
+        .map(([fileName]) => fileName);
+
+    const duplicateSet = new Set(duplicateFileNames);
+    const rows: BulkImportPreviewRow[] = [];
+    const fileByDocId = new Map<string, File>();
+    let matchedCount = 0;
+    let missingCount = 0;
+
+    for (const item of items) {
+        const expectedFileName = `${item.docName}${MARKDOWN_EXTENSION}`;
+        const matchedFiles = markdownFilesByName.get(expectedFileName) || [];
+
+        if (duplicateSet.has(expectedFileName)) {
+            rows.push({
+                docId: item.docId,
+                docName: item.docName,
+                expectedFileName,
+                status: 'duplicate',
+                file: null,
+            });
+            continue;
+        }
+
+        if (matchedFiles.length === 1) {
+            rows.push({
+                docId: item.docId,
+                docName: item.docName,
+                expectedFileName,
+                status: 'matched',
+                file: matchedFiles[0],
+            });
+            fileByDocId.set(item.docId, matchedFiles[0]);
+            matchedCount++;
+            continue;
+        }
+
+        rows.push({
+            docId: item.docId,
+            docName: item.docName,
+            expectedFileName,
+            status: 'missing',
+            file: null,
+        });
+        missingCount++;
+    }
+
+    return {
+        totalFiles: files.length,
+        totalDocs: items.length,
+        matchedCount,
+        missingCount,
+        duplicateFileNames,
+        blockedFiles,
+        ignoredFiles,
+        rows,
+        fileByDocId,
+        hasBlockingErrors: blockedFiles.length > 0 || duplicateFileNames.length > 0,
+    };
+}
+
+function _sanitizeImportHtml(html: string): string {
+    const doc = new DOMParser().parseFromString(`<div id="ffne-import-root">${html}</div>`, 'text/html');
+    const root = doc.getElementById('ffne-import-root');
+    if (!root) return '';
+
+    root.querySelectorAll('script, style, iframe, object, embed, link, meta').forEach(el => el.remove());
+    root.querySelectorAll('*').forEach(el => {
+        Array.from(el.attributes).forEach(attr => {
+            const name = attr.name.toLowerCase();
+            const value = attr.value.trim().toLowerCase();
+            if (name.startsWith('on')) {
+                el.removeAttribute(attr.name);
+                return;
+            }
+            if ((name === 'href' || name === 'src') && /^(javascript|data):/.test(value)) {
+                el.removeAttribute(attr.name);
+            }
+        });
+    });
+
+    return root.innerHTML;
+}
+
+function _markdownToImportHtml(markdown: string): string {
+    return _sanitizeImportHtml(SimpleMarkdownParser.parse(markdown));
+}
+
+function _readFileAsText(file: File): Promise<string> {
+    if (typeof file.text === 'function') {
+        return file.text();
+    }
+
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(String(reader.result || ''));
+        reader.onerror = () => reject(reader.error || new Error('Failed to read file.'));
+        reader.readAsText(file);
+    });
+}
 
 /**
  * Two-pass retry orchestrator for bulk operations.
@@ -30,20 +256,7 @@ async function _runBulkOperation(e: MouseEvent, config: IBulkOperationConfig): P
         return;
     }
 
-    const allRows = Core.getElements(Elements.DOC_TABLE_BODY_ROWS);
-
-    let items: IBulkItem[] = [];
-    for (const row of allRows) {
-        const editLink = row.querySelector('a[href*="docid="]') as HTMLAnchorElement;
-        if (!editLink) continue;
-        const match = editLink.href.match(/docid=(\d+)/);
-        if (!match) continue;
-        items.push({
-            docId: match[1],
-            title: (row as HTMLTableRowElement).cells[1].innerText.trim().replace(/[/\\?%*:|"<>]/g, '-'),
-            row: row as HTMLTableRowElement,
-        });
-    }
+    let items = _collectBulkItems();
 
     if (config.filterRows) {
         items = config.filterRows(items);
@@ -127,6 +340,10 @@ export const DocManager = {
 
     /** Cache for dynamically-resolved Life column index. null = not resolved yet. */
     _lifeColIdx: null as number | null,
+
+    _advancedEscHandler: null as ((e: KeyboardEvent) => void) | null,
+    _importEscHandler: null as ((e: KeyboardEvent) => void) | null,
+    _bulkImportPlan: null as BulkImportPlan | null,
 
     /**
      * Scans table header for "Life" cell to resolve column index dynamically.
@@ -216,87 +433,416 @@ export const DocManager = {
      * Orchestrator for injecting all UI elements (Buttons, Columns).
      */
     injectUI: function () {
-        this.injectBulkButton();
-        this.injectRefreshAllButton();
+        this.injectAdvancedDrawer();
         this.injectTableColumn();
     },
 
     /**
-     * Injects the floating "Download All" button into the interface.
-     * Finds the "Document Manager" label or falls back to the main content wrapper.
+     * Injects the bottom-centre advanced routines drawer for Doc Manager bulk flows.
      */
-    injectBulkButton: function () {
-        const log = Core.getLogger(this.MODULE_NAME, 'injectBulkButton');
-        log('Attempting to inject UI...');
+    injectAdvancedDrawer: function () {
+        const log = Core.getLogger(this.MODULE_NAME, 'injectAdvancedDrawer');
+        if (document.getElementById(ADVANCED_DRAWER_ID)) return;
 
-        let container = Core.getElement(Elements.DOC_MANAGER_LABEL);
+        this._injectAdvancedStyles();
 
-        // Fallback to Main Content Wrapper if the label isn't found
-        if (!container) {
-            container = Core.getElement(Elements.MAIN_CONTENT_WRAPPER);
-        }
-
-        if (!container) return log('ERROR: Container not found.');
-
-        if (getComputedStyle(container).position === 'static') {
-            container.style.position = 'relative';
-        }
-
-        const btn = document.createElement('button');
-        btn.innerText = "↓ All";
-        btn.title = "Download all documents (format set in Tampermonkey menu)";
-        btn.style.cssText = `
-            position: absolute; right: 50px; top: 50%; transform: translateY(-50%); z-index: 99;
-            appearance: none; background: transparent; border: 0; outline: none; box-shadow: none;
-            font-family: inherit; font-size: 12px; font-weight: 600; color: inherit; cursor: pointer;
-            padding: 6px 10px; border-radius: 4px; opacity: 0.6; transition: opacity 0.2s, background-color 0.2s;
+        const drawer = document.createElement('div');
+        drawer.id = ADVANCED_DRAWER_ID;
+        drawer.innerHTML = `
+            <button type="button" class="ffne-dm-drawer-btn" title="Open advanced document routines">
+                Advanced
+            </button>
         `;
 
-        btn.onmouseover = () => { btn.style.opacity = "1"; btn.style.backgroundColor = "rgba(128, 128, 128, 0.15)"; };
-        btn.onmouseout = () => { btn.style.opacity = "0.6"; btn.style.backgroundColor = "transparent"; };
-        btn.onclick = this.runBulkExport.bind(this);
+        const button = drawer.querySelector<HTMLButtonElement>('button');
+        button?.addEventListener('click', () => this.openAdvancedRoutinesModal());
 
-        container.appendChild(btn);
-        log('Bulk Button injected.');
+        document.body.appendChild(drawer);
+        log('Advanced drawer injected.');
     },
 
-    /**
-     * Injects the floating "Refresh All" button into the interface.
-     * Positioned next to the "Download All" button.
-     */
-    injectRefreshAllButton: function () {
-        const log = Core.getLogger(this.MODULE_NAME, 'injectRefreshAllButton');
-        log('Attempting to inject Refresh All button...');
+    _injectAdvancedStyles: function () {
+        if (document.getElementById(ADVANCED_STYLE_ID)) return;
 
-        let container = Core.getElement(Elements.DOC_MANAGER_LABEL);
+        const style = document.createElement('style');
+        style.id = ADVANCED_STYLE_ID;
+        style.textContent = `
+            #${ADVANCED_DRAWER_ID} {
+                position: fixed;
+                left: 50%;
+                bottom: 12px;
+                transform: translateX(-50%);
+                z-index: 99998;
+                font-family: Verdana, Arial, sans-serif;
+            }
+            .ffne-dm-drawer-btn,
+            .ffne-dm-btn {
+                appearance: none;
+                border: 1px solid #7892ad;
+                background: #f0f4f8;
+                color: #234d73;
+                font-family: Verdana, Arial, sans-serif;
+                font-size: 12px;
+                line-height: 18px;
+                padding: 4px 10px;
+                border-radius: 3px;
+                cursor: pointer;
+                box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
+            }
+            .ffne-dm-drawer-btn:hover,
+            .ffne-dm-btn:hover {
+                background: #e3edf7;
+                color: #123a5a;
+            }
+            .ffne-dm-btn:disabled {
+                color: #777;
+                cursor: default;
+                opacity: 0.65;
+            }
+            .ffne-dm-overlay {
+                position: fixed;
+                inset: 0;
+                z-index: 99999;
+                background: rgba(0, 0, 0, 0.35);
+                font-family: Verdana, Arial, sans-serif;
+            }
+            .ffne-dm-modal {
+                position: absolute;
+                left: 50%;
+                top: 50%;
+                transform: translate(-50%, -50%);
+                width: min(720px, calc(100vw - 32px));
+                max-height: min(760px, calc(100vh - 32px));
+                overflow: auto;
+                background: #fff;
+                border: 1px solid #7892ad;
+                box-shadow: 0 3px 18px rgba(0, 0, 0, 0.35);
+            }
+            .ffne-dm-modal-sm {
+                width: min(460px, calc(100vw - 32px));
+            }
+            .ffne-dm-modal-header {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                gap: 12px;
+                background: #336699;
+                color: #fff;
+                padding: 7px 10px;
+                border-bottom: 1px solid #254d73;
+            }
+            .ffne-dm-modal-header h3 {
+                margin: 0;
+                font-size: 13px;
+                line-height: 18px;
+                font-weight: 700;
+            }
+            .ffne-dm-close {
+                appearance: none;
+                border: 0;
+                background: transparent;
+                color: #fff;
+                cursor: pointer;
+                font-size: 18px;
+                line-height: 18px;
+                padding: 0 4px;
+            }
+            .ffne-dm-modal-body {
+                padding: 12px;
+                color: #333;
+                font-size: 12px;
+            }
+            .ffne-dm-routines {
+                display: grid;
+                gap: 8px;
+            }
+            .ffne-dm-routine {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                gap: 12px;
+                border: 1px solid #d8d8d8;
+                background: #fafafa;
+                padding: 8px;
+            }
+            .ffne-dm-routine-title {
+                font-weight: 700;
+                color: #333;
+            }
+            .ffne-dm-import-controls {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                gap: 8px;
+                flex-wrap: wrap;
+                margin-bottom: 10px;
+            }
+            .ffne-dm-file-input {
+                font-family: Verdana, Arial, sans-serif;
+                font-size: 12px;
+                max-width: 100%;
+            }
+            .ffne-dm-summary {
+                margin: 8px 0;
+                padding: 7px 8px;
+                background: #f7f9fb;
+                border: 1px solid #d8e2ec;
+            }
+            .ffne-dm-warning {
+                color: #8a3b00;
+                background: #fff8e8;
+                border-color: #e8c98a;
+            }
+            .ffne-dm-error {
+                color: #8b0000;
+                background: #fff0f0;
+                border-color: #d8a0a0;
+            }
+            .ffne-dm-preview {
+                width: 100%;
+                border-collapse: collapse;
+                margin-top: 8px;
+            }
+            .ffne-dm-preview th {
+                background: #f0f4f8;
+                color: #333;
+                border: 1px solid #c8d6e4;
+                padding: 5px 6px;
+                text-align: left;
+            }
+            .ffne-dm-preview td {
+                border: 1px solid #ddd;
+                padding: 5px 6px;
+                vertical-align: top;
+            }
+            .ffne-dm-status-matched { color: #236423; font-weight: 700; }
+            .ffne-dm-status-missing { color: #777; }
+            .ffne-dm-status-duplicate { color: #8b0000; font-weight: 700; }
+            .ffne-dm-footer {
+                display: flex;
+                justify-content: flex-end;
+                align-items: center;
+                gap: 8px;
+                margin-top: 10px;
+            }
+            .ffne-dm-run-status {
+                margin-right: auto;
+                color: #555;
+            }
+        `;
+        document.head.appendChild(style);
+    },
 
-        // Fallback to Main Content Wrapper if the label isn't found
-        if (!container) {
-            container = Core.getElement(Elements.MAIN_CONTENT_WRAPPER);
-        }
+    openAdvancedRoutinesModal: function () {
+        if (document.getElementById(ADVANCED_MODAL_ID)) return;
 
-        if (!container) return log('ERROR: Container not found.');
+        this._injectAdvancedStyles();
 
-        if (getComputedStyle(container).position === 'static') {
-            container.style.position = 'relative';
-        }
-
-        const btn = document.createElement('button');
-        btn.innerText = "↻ All";
-        btn.title = "Refresh all documents (re-save to trigger FFN processing)";
-        btn.style.cssText = `
-            position: absolute; right: 0px; top: 50%; transform: translateY(-50%); z-index: 99;
-            appearance: none; background: transparent; border: 0; outline: none; box-shadow: none;
-            font-family: inherit; font-size: 12px; font-weight: 600; color: inherit; cursor: pointer;
-            padding: 6px 10px; border-radius: 4px; opacity: 0.6; transition: opacity 0.2s, background-color 0.2s;
+        const overlay = document.createElement('div');
+        overlay.id = ADVANCED_MODAL_ID;
+        overlay.className = 'ffne-dm-overlay';
+        overlay.innerHTML = `
+            <div class="ffne-dm-modal ffne-dm-modal-sm" role="dialog" aria-modal="true" aria-labelledby="ffne-dm-advanced-title">
+                <div class="ffne-dm-modal-header">
+                    <h3 id="ffne-dm-advanced-title">Advanced Routines</h3>
+                    <button type="button" class="ffne-dm-close" aria-label="Close">x</button>
+                </div>
+                <div class="ffne-dm-modal-body">
+                    <div class="ffne-dm-routines">
+                        <div class="ffne-dm-routine">
+                            <span class="ffne-dm-routine-title">Bulk Export</span>
+                            <button type="button" class="ffne-dm-btn" data-ffne-action="bulk-export">Run</button>
+                        </div>
+                        <div class="ffne-dm-routine">
+                            <span class="ffne-dm-routine-title">Bulk Refresh</span>
+                            <button type="button" class="ffne-dm-btn" data-ffne-action="bulk-refresh">Run</button>
+                        </div>
+                        <div class="ffne-dm-routine">
+                            <span class="ffne-dm-routine-title">Bulk Import</span>
+                            <button type="button" class="ffne-dm-btn" data-ffne-action="bulk-import">Open</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
         `;
 
-        btn.onmouseover = () => { btn.style.opacity = "1"; btn.style.backgroundColor = "rgba(128, 128, 128, 0.15)"; };
-        btn.onmouseout = () => { btn.style.opacity = "0.6"; btn.style.backgroundColor = "transparent"; };
-        btn.onclick = this.runBulkRefresh.bind(this);
+        overlay.addEventListener('click', (e) => {
+            if (e.target === overlay) this.closeAdvancedRoutinesModal();
+        });
 
-        container.appendChild(btn);
-        log('Refresh All Button injected.');
+        overlay.querySelector<HTMLButtonElement>('.ffne-dm-close')
+            ?.addEventListener('click', () => this.closeAdvancedRoutinesModal());
+
+        overlay.querySelector<HTMLButtonElement>('[data-ffne-action="bulk-export"]')
+            ?.addEventListener('click', (e) => this.runBulkExport(e as MouseEvent));
+
+        overlay.querySelector<HTMLButtonElement>('[data-ffne-action="bulk-refresh"]')
+            ?.addEventListener('click', (e) => this.runBulkRefresh(e as MouseEvent));
+
+        overlay.querySelector<HTMLButtonElement>('[data-ffne-action="bulk-import"]')
+            ?.addEventListener('click', () => {
+                this.closeAdvancedRoutinesModal();
+                this.openBulkImportModal();
+            });
+
+        this._advancedEscHandler = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') this.closeAdvancedRoutinesModal();
+        };
+        document.addEventListener('keydown', this._advancedEscHandler);
+
+        document.body.appendChild(overlay);
+    },
+
+    closeAdvancedRoutinesModal: function () {
+        const modal = document.getElementById(ADVANCED_MODAL_ID);
+        if (modal) modal.remove();
+
+        if (this._advancedEscHandler) {
+            document.removeEventListener('keydown', this._advancedEscHandler);
+            this._advancedEscHandler = null;
+        }
+    },
+
+    openBulkImportModal: function () {
+        if (document.getElementById(IMPORT_MODAL_ID)) return;
+
+        this._injectAdvancedStyles();
+        this._bulkImportPlan = null;
+
+        const overlay = document.createElement('div');
+        overlay.id = IMPORT_MODAL_ID;
+        overlay.className = 'ffne-dm-overlay';
+        overlay.innerHTML = `
+            <div class="ffne-dm-modal" role="dialog" aria-modal="true" aria-labelledby="ffne-dm-import-title">
+                <div class="ffne-dm-modal-header">
+                    <h3 id="ffne-dm-import-title">Bulk Import Markdown</h3>
+                    <button type="button" class="ffne-dm-close" aria-label="Close">x</button>
+                </div>
+                <div class="ffne-dm-modal-body">
+                    <div class="ffne-dm-import-controls">
+                        <input id="ffne-dm-import-input" class="ffne-dm-file-input" type="file" accept=".md,text/markdown" webkitdirectory multiple>
+                        <button type="button" id="ffne-dm-import-start" class="ffne-dm-btn" disabled>Import</button>
+                    </div>
+                    <div id="ffne-dm-import-preview" class="ffne-dm-summary">Select a folder containing Markdown files.</div>
+                    <div class="ffne-dm-footer">
+                        <span id="ffne-dm-import-status" class="ffne-dm-run-status"></span>
+                        <button type="button" class="ffne-dm-btn" data-ffne-action="close-import">Close</button>
+                    </div>
+                </div>
+            </div>
+        `;
+
+        const input = overlay.querySelector<HTMLInputElement>('#ffne-dm-import-input');
+        const startButton = overlay.querySelector<HTMLButtonElement>('#ffne-dm-import-start');
+        const preview = overlay.querySelector<HTMLElement>('#ffne-dm-import-preview');
+        const status = overlay.querySelector<HTMLElement>('#ffne-dm-import-status');
+
+        input?.addEventListener('change', () => {
+            const files = Array.from(input.files || []);
+            const plan = _buildBulkImportPlan(files);
+            this._bulkImportPlan = plan;
+            if (preview && startButton) {
+                this._renderBulkImportPreview(preview, startButton, plan);
+            }
+            if (status) status.textContent = '';
+        });
+
+        startButton?.addEventListener('click', async (e) => {
+            const plan = this._bulkImportPlan;
+            if (!plan || plan.hasBlockingErrors || plan.matchedCount === 0) return;
+
+            const confirmed = confirm(
+                `Bulk Import will replace ${plan.matchedCount} document(s) with matched Markdown files.\n\n` +
+                'This cannot be undone from FFN Enhancements. Continue?'
+            );
+            if (!confirmed) return;
+
+            await this.runBulkImport(e as MouseEvent, plan, status || undefined);
+        });
+
+        overlay.querySelector<HTMLButtonElement>('.ffne-dm-close')
+            ?.addEventListener('click', () => this.closeBulkImportModal());
+        overlay.querySelector<HTMLButtonElement>('[data-ffne-action="close-import"]')
+            ?.addEventListener('click', () => this.closeBulkImportModal());
+
+        overlay.addEventListener('click', (e) => {
+            if (e.target === overlay) this.closeBulkImportModal();
+        });
+
+        this._importEscHandler = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') this.closeBulkImportModal();
+        };
+        document.addEventListener('keydown', this._importEscHandler);
+
+        document.body.appendChild(overlay);
+    },
+
+    closeBulkImportModal: function () {
+        const modal = document.getElementById(IMPORT_MODAL_ID);
+        if (modal) modal.remove();
+
+        if (this._importEscHandler) {
+            document.removeEventListener('keydown', this._importEscHandler);
+            this._importEscHandler = null;
+        }
+
+        this._bulkImportPlan = null;
+    },
+
+    _renderBulkImportPreview: function (
+        preview: HTMLElement,
+        startButton: HTMLButtonElement,
+        plan: BulkImportPlan,
+    ) {
+        const canImport = !plan.hasBlockingErrors && plan.matchedCount > 0;
+        startButton.disabled = !canImport;
+
+        const summaryClass = plan.hasBlockingErrors
+            ? 'ffne-dm-summary ffne-dm-error'
+            : plan.ignoredFiles.length > 0 || plan.missingCount > 0
+                ? 'ffne-dm-summary ffne-dm-warning'
+                : 'ffne-dm-summary';
+
+        const blockedHtml = plan.blockedFiles.length > 0
+            ? `<div><strong>Blocked:</strong> ${plan.blockedFiles.map(_escapeHtml).join(', ')}</div>`
+            : '';
+        const duplicateHtml = plan.duplicateFileNames.length > 0
+            ? `<div><strong>Duplicates:</strong> ${plan.duplicateFileNames.map(_escapeHtml).join(', ')}</div>`
+            : '';
+        const ignoredHtml = plan.ignoredFiles.length > 0
+            ? `<div><strong>Ignored:</strong> ${plan.ignoredFiles.slice(0, 8).map(_escapeHtml).join(', ')}${plan.ignoredFiles.length > 8 ? '...' : ''}</div>`
+            : '';
+
+        const rowsHtml = plan.rows.map(row => `
+            <tr>
+                <td>${_escapeHtml(row.docName)}</td>
+                <td>${_escapeHtml(row.expectedFileName)}</td>
+                <td class="ffne-dm-status-${row.status}">${row.status}</td>
+            </tr>
+        `).join('');
+
+        preview.className = summaryClass;
+        preview.innerHTML = `
+            <div>
+                <strong>${plan.matchedCount}</strong> matched,
+                <strong>${plan.missingCount}</strong> missing,
+                <strong>${plan.duplicateFileNames.length}</strong> duplicate,
+                <strong>${plan.ignoredFiles.length}</strong> ignored.
+            </div>
+            ${blockedHtml}
+            ${duplicateHtml}
+            ${ignoredHtml}
+            <table class="ffne-dm-preview">
+                <thead>
+                    <tr>
+                        <th>DocManager Name</th>
+                        <th>Expected File</th>
+                        <th>Status</th>
+                    </tr>
+                </thead>
+                <tbody>${rowsHtml || '<tr><td colspan="3">No documents found.</td></tr>'}</tbody>
+            </table>
+        `;
     },
 
     /**
@@ -354,7 +900,7 @@ export const DocManager = {
             if (!match) return;
             const docId = match[1];
 
-            const title = (row as HTMLTableRowElement).cells[1].innerText.trim().replace(/[/\\?%*:|"<>]/g, '-');
+            const title = _sanitizeDocTitle(_getCellText((row as HTMLTableRowElement).cells[1]));
 
             // Add Copy cell
             const copyTd = document.createElement('td');
@@ -706,6 +1252,86 @@ export const DocManager = {
         });
     },
 
+    /**
+     * Handles Markdown-only bulk import for matched DocManager rows.
+     */
+    runBulkImport: async function (e: MouseEvent, plan: BulkImportPlan, statusEl?: HTMLElement) {
+        const log = Core.getLogger(this.MODULE_NAME, 'runBulkImport');
+        const btn = e.currentTarget as HTMLButtonElement;
+
+        if (plan.hasBlockingErrors || plan.matchedCount === 0) {
+            if (statusEl) statusEl.textContent = 'Import blocked.';
+            log('Import blocked by validation state.', {
+                blockedFiles: plan.blockedFiles,
+                duplicateFileNames: plan.duplicateFileNames,
+                matchedCount: plan.matchedCount,
+            });
+            return;
+        }
+
+        if (statusEl) statusEl.textContent = `Importing ${plan.matchedCount} document(s)...`;
+
+        await _runBulkOperation(e, {
+            verb: 'Import',
+            filterRows: (items) => items.filter(item => plan.fileByDocId.has(item.docId)),
+            processItem: async (item) => {
+                const file = plan.fileByDocId.get(item.docId);
+                if (!file) return false;
+
+                const originalBg = item.row.style.backgroundColor;
+                item.row.style.backgroundColor = '#fff4c2';
+                item.row.style.transition = 'background-color 0.3s ease';
+
+                try {
+                    const markdown = await _readFileAsText(file);
+                    if (!markdown.trim()) {
+                        log(`Skipping "${item.docName}" because matched file is empty.`);
+                        return false;
+                    }
+
+                    const html = _markdownToImportHtml(markdown);
+                    if (!html.trim()) {
+                        log(`Skipping "${item.docName}" because Markdown conversion produced no HTML.`);
+                        return false;
+                    }
+
+                    return await DocFetchService.replacePrivateDocContent(item.docId, item.title, html);
+                } catch (err) {
+                    log(`Failed to import "${item.docName}".`, err);
+                    return false;
+                } finally {
+                    item.row.style.backgroundColor = originalBg;
+                }
+            },
+            onItemSuccess: (item, pass) => {
+                DocManager.updateLifeColumn(item.row, `bulk import pass ${pass}: ${item.title}`);
+            },
+            onPermanentFailure: (item) => {
+                log(`Permanent import failure for "${item.docName}".`);
+            },
+            onFinalize: ({ successCount, totalCount }) => {
+                const failedCount = totalCount - successCount;
+                if (successCount === totalCount) {
+                    btn.innerText = 'Done';
+                    if (statusEl) statusEl.textContent = `Imported all ${successCount} document(s).`;
+                    log(`Successfully imported all ${successCount} documents.`);
+                } else if (successCount > 0) {
+                    btn.innerText = `${successCount}/${totalCount}`;
+                    if (statusEl) statusEl.textContent = `Imported ${successCount}; failed ${failedCount}.`;
+                    log(`Imported ${successCount} of ${totalCount} documents.`);
+                } else {
+                    btn.innerText = 'Failed';
+                    if (statusEl) statusEl.textContent = 'No documents imported.';
+                    log('Failed to import any documents.');
+                }
+            },
+        });
+    },
+
     // Exported for tests — verifies button-reference lifecycle in onFinalize callbacks.
     _runBulkOperation,
+    _buildBulkImportPlan,
+    _getTopLevelFileName,
+    _markdownToImportHtml,
+    _sanitizeImportHtml,
 };

--- a/src/modules/DocManager.ts
+++ b/src/modules/DocManager.ts
@@ -257,10 +257,10 @@ function _renderBulkImportFailures(container: HTMLElement | null | undefined, fa
     container.hidden = false;
     container.innerHTML = `
         <div class="ffne-dm-import-results-title">Failed Imports</div>
-        <table class="ffne-dm-preview">
+        <table class="ffne-dm-preview" contenteditable="false">
             <thead>
                 <tr>
-                    <th>DocManager Name</th>
+                    <th>Doc</th>
                     <th>Selected File</th>
                     <th>Reason</th>
                 </tr>
@@ -700,6 +700,8 @@ export const DocManager = {
                 width: 100%;
                 border-collapse: collapse;
                 margin-top: 8px;
+                cursor: default;
+                user-select: none;
             }
             .ffne-dm-preview th {
                 background: #f0f4f8;
@@ -707,11 +709,13 @@ export const DocManager = {
                 border: 1px solid #c8d6e4;
                 padding: 5px 6px;
                 text-align: left;
+                cursor: default;
             }
             .ffne-dm-preview td {
                 border: 1px solid #ddd;
                 padding: 5px 6px;
                 vertical-align: top;
+                cursor: default;
             }
             .ffne-dm-status-matched { color: #236423; font-weight: 700; }
             .ffne-dm-status-missing { color: #777; }
@@ -983,10 +987,10 @@ export const DocManager = {
             ${blockedHtml}
             ${duplicateHtml}
             ${ignoredHtml}
-            <table class="ffne-dm-preview">
+            <table class="ffne-dm-preview" contenteditable="false">
                 <thead>
                     <tr>
-                        <th>DocManager Name</th>
+                        <th>Doc</th>
                         <th>Selected File</th>
                         <th>Status</th>
                     </tr>

--- a/src/modules/DocManager.ts
+++ b/src/modules/DocManager.ts
@@ -44,6 +44,12 @@ interface BulkImportPlan {
     hasBlockingErrors: boolean;
 }
 
+interface BulkImportFailure {
+    docName: string;
+    fileName: string;
+    reason: string;
+}
+
 function _sanitizeDocTitle(title: string): string {
     return title.trim().replace(/[/\\?%*:|"<>]/g, '-');
 }
@@ -231,6 +237,39 @@ function _markdownToImportHtml(markdown: string): string {
     return _sanitizeImportHtml(SimpleMarkdownParser.parse(markdown));
 }
 
+function _renderBulkImportFailures(container: HTMLElement | null | undefined, failures: BulkImportFailure[]): void {
+    if (!container) return;
+
+    if (failures.length === 0) {
+        container.hidden = true;
+        container.innerHTML = '';
+        return;
+    }
+
+    const rowsHtml = failures.map(failure => `
+        <tr>
+            <td>${_escapeHtml(failure.docName)}</td>
+            <td>${_escapeHtml(failure.fileName)}</td>
+            <td>${_escapeHtml(failure.reason)}</td>
+        </tr>
+    `).join('');
+
+    container.hidden = false;
+    container.innerHTML = `
+        <div class="ffne-dm-import-results-title">Failed Imports</div>
+        <table class="ffne-dm-preview">
+            <thead>
+                <tr>
+                    <th>DocManager Name</th>
+                    <th>Selected File</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>${rowsHtml}</tbody>
+        </table>
+    `;
+}
+
 function _readFileAsText(file: File): Promise<string> {
     if (typeof file.text === 'function') {
         return file.text();
@@ -251,7 +290,7 @@ function _readFileAsText(file: File): Promise<string> {
  */
 async function _runBulkOperation(e: MouseEvent, config: IBulkOperationConfig): Promise<void> {
     const log = Core.getLogger(DocManager.MODULE_NAME, '_runBulkOperation');
-    const { verb, processItem, onItemSuccess, onPermanentFailure, preBatch, onFinalize } = config;
+    const { verb, processItem, onItemStart, onItemSuccess, onPermanentFailure, preBatch, onFinalize } = config;
 
     log(`${verb} initiated.`);
     const btn = e.currentTarget as HTMLButtonElement;
@@ -287,6 +326,7 @@ async function _runBulkOperation(e: MouseEvent, config: IBulkOperationConfig): P
         for (let i = 0; i < items.length; i++) {
             const item = items[i];
             btn.innerText = `${i + 1}/${items.length}`;
+            if (onItemStart) onItemStart(item, 1, i + 1, items.length);
 
             await new Promise(r => setTimeout(r, SettingsManager.get('bulkExportDelayMs')));
 
@@ -307,6 +347,7 @@ async function _runBulkOperation(e: MouseEvent, config: IBulkOperationConfig): P
             for (let i = 0; i < retriedItems.length; i++) {
                 const item = retriedItems[i];
                 btn.innerText = `Retry ${i + 1}/${retriedItems.length}`;
+                if (onItemStart) onItemStart(item, 2, i + 1, retriedItems.length);
 
                 await new Promise(r => setTimeout(r, SettingsManager.get('bulkRetryDelayMs')));
 
@@ -642,6 +683,20 @@ export const DocManager = {
                 margin-right: auto;
                 color: #555;
             }
+            .ffne-dm-import-results {
+                margin-top: 10px;
+                padding: 7px 8px;
+                color: #8b0000;
+                background: #fff0f0;
+                border: 1px solid #d8a0a0;
+            }
+            .ffne-dm-import-results[hidden] {
+                display: none;
+            }
+            .ffne-dm-import-results-title {
+                font-weight: 700;
+                margin-bottom: 6px;
+            }
         `;
         document.head.appendChild(style);
     },
@@ -743,6 +798,7 @@ export const DocManager = {
                         <button type="button" id="ffne-dm-import-start" class="ffne-dm-btn" disabled>Import</button>
                     </div>
                     <div id="ffne-dm-import-preview" class="ffne-dm-summary">Select a folder or Markdown files.</div>
+                    <div id="ffne-dm-import-results" class="ffne-dm-import-results" hidden></div>
                     <div class="ffne-dm-footer">
                         <span id="ffne-dm-import-status" class="ffne-dm-run-status"></span>
                         <button type="button" class="ffne-dm-btn" data-ffne-action="close-import">Close</button>
@@ -759,6 +815,7 @@ export const DocManager = {
         const preview = overlay.querySelector<HTMLElement>('#ffne-dm-import-preview');
         const status = overlay.querySelector<HTMLElement>('#ffne-dm-import-status');
         const selection = overlay.querySelector<HTMLElement>('#ffne-dm-import-selection');
+        const results = overlay.querySelector<HTMLElement>('#ffne-dm-import-results');
 
         const updateSelectedFiles = (input: HTMLInputElement, sourceLabel: string) => {
             const files = Array.from(input.files || []);
@@ -767,6 +824,7 @@ export const DocManager = {
             if (preview && startButton) {
                 this._renderBulkImportPreview(preview, startButton, plan);
             }
+            _renderBulkImportFailures(results, []);
             if (selection) {
                 const count = files.length;
                 selection.textContent = count === 1
@@ -806,7 +864,7 @@ export const DocManager = {
             );
             if (!confirmed) return;
 
-            await this.runBulkImport(e as MouseEvent, plan, status || undefined);
+            await this.runBulkImport(e as MouseEvent, plan, status || undefined, results || undefined);
         });
 
         overlay.querySelector<HTMLButtonElement>('.ffne-dm-close')
@@ -1304,12 +1362,29 @@ export const DocManager = {
     /**
      * Handles Markdown-only bulk import for matched DocManager rows.
      */
-    runBulkImport: async function (e: MouseEvent, plan: BulkImportPlan, statusEl?: HTMLElement) {
+    runBulkImport: async function (
+        e: MouseEvent,
+        plan: BulkImportPlan,
+        statusEl?: HTMLElement,
+        resultsEl?: HTMLElement,
+    ) {
         const log = Core.getLogger(this.MODULE_NAME, 'runBulkImport');
         const btn = e.currentTarget as HTMLButtonElement;
+        const failureReasons = new Map<string, string>();
+        const failures: BulkImportFailure[] = [];
+
+        const setFailure = (item: IBulkItem, reason: string) => {
+            failureReasons.set(item.docId, reason);
+        };
+
+        const fileLabelFor = (item: IBulkItem): string => {
+            const file = plan.fileByDocId.get(item.docId);
+            return file ? _getFileDisplayPath(file) : '(no matched file)';
+        };
 
         if (plan.hasBlockingErrors || plan.matchedCount === 0) {
             if (statusEl) statusEl.textContent = 'Import blocked.';
+            _renderBulkImportFailures(resultsEl, []);
             log('Import blocked by validation state.', {
                 blockedFiles: plan.blockedFiles,
                 duplicateFileNames: plan.duplicateFileNames,
@@ -1318,14 +1393,23 @@ export const DocManager = {
             return;
         }
 
-        if (statusEl) statusEl.textContent = `Importing ${plan.matchedCount} document(s)...`;
+        if (statusEl) statusEl.textContent = `Preparing to import ${plan.matchedCount} document(s)...`;
+        _renderBulkImportFailures(resultsEl, []);
 
         await _runBulkOperation(e, {
             verb: 'Import',
             filterRows: (items) => items.filter(item => plan.fileByDocId.has(item.docId)),
+            onItemStart: (item, pass, index, total) => {
+                if (!statusEl) return;
+                const verb = pass === 2 ? 'Retrying' : 'Importing';
+                statusEl.textContent = `${verb} ${index}/${total}: ${item.docName} from ${fileLabelFor(item)}...`;
+            },
             processItem: async (item) => {
                 const file = plan.fileByDocId.get(item.docId);
-                if (!file) return false;
+                if (!file) {
+                    setFailure(item, 'No matched Markdown file was found.');
+                    return false;
+                }
 
                 const originalBg = item.row.style.backgroundColor;
                 item.row.style.backgroundColor = '#fff4c2';
@@ -1335,18 +1419,29 @@ export const DocManager = {
                     const markdown = await _readFileAsText(file);
                     if (!markdown.trim()) {
                         log(`Skipping "${item.docName}" because matched file is empty.`);
+                        setFailure(item, 'Matched Markdown file is empty.');
                         return false;
                     }
 
                     const html = _markdownToImportHtml(markdown);
                     if (!html.trim()) {
                         log(`Skipping "${item.docName}" because Markdown conversion produced no HTML.`);
+                        setFailure(item, 'Markdown conversion produced no importable HTML.');
                         return false;
                     }
 
-                    return await DocFetchService.replacePrivateDocContent(item.docId, item.title, html);
+                    const result = await DocFetchService.replacePrivateDocContentWithResult(item.docId, item.title, html);
+                    if (!result.ok) {
+                        setFailure(item, result.reason || 'FFN did not confirm the save.');
+                        return false;
+                    }
+
+                    failureReasons.delete(item.docId);
+                    return true;
                 } catch (err) {
                     log(`Failed to import "${item.docName}".`, err);
+                    const reason = err instanceof Error ? err.message : String(err);
+                    setFailure(item, `Unexpected error: ${reason}`);
                     return false;
                 } finally {
                     item.row.style.backgroundColor = originalBg;
@@ -1357,9 +1452,15 @@ export const DocManager = {
             },
             onPermanentFailure: (item) => {
                 log(`Permanent import failure for "${item.docName}".`);
+                failures.push({
+                    docName: item.docName,
+                    fileName: fileLabelFor(item),
+                    reason: failureReasons.get(item.docId) || 'Import failed after retry.',
+                });
             },
             onFinalize: ({ successCount, totalCount }) => {
                 const failedCount = totalCount - successCount;
+                _renderBulkImportFailures(resultsEl, failures);
                 if (successCount === totalCount) {
                     btn.innerText = 'Done';
                     if (statusEl) statusEl.textContent = `Imported all ${successCount} document(s).`;

--- a/src/modules/DocManager.ts
+++ b/src/modules/DocManager.ts
@@ -495,8 +495,14 @@ export const DocManager = {
         const drawer = document.createElement('div');
         drawer.id = ADVANCED_DRAWER_ID;
         drawer.innerHTML = `
-            <button type="button" class="ffne-dm-drawer-btn" title="Open advanced document routines">
-                Advanced
+            <button
+                type="button"
+                class="ffne-dm-drawer-pull"
+                title="Open advanced document routines"
+                aria-label="Open advanced document routines"
+            >
+                <span class="ffne-dm-drawer-grabber" aria-hidden="true"></span>
+                <span class="ffne-dm-drawer-chevron" aria-hidden="true"></span>
             </button>
         `;
 
@@ -516,12 +522,11 @@ export const DocManager = {
             #${ADVANCED_DRAWER_ID} {
                 position: fixed;
                 left: 50%;
-                bottom: 12px;
+                bottom: 0;
                 transform: translateX(-50%);
                 z-index: 99998;
-                font-family: Verdana, Arial, sans-serif;
+                line-height: 0;
             }
-            .ffne-dm-drawer-btn,
             .ffne-dm-btn {
                 appearance: none;
                 border: 1px solid #7892ad;
@@ -535,10 +540,49 @@ export const DocManager = {
                 cursor: pointer;
                 box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
             }
-            .ffne-dm-drawer-btn:hover,
             .ffne-dm-btn:hover {
                 background: #e3edf7;
                 color: #123a5a;
+            }
+            .ffne-dm-drawer-pull {
+                appearance: none;
+                width: 154px;
+                height: 28px;
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                gap: 3px;
+                padding: 3px 0 4px;
+                border: 1px solid ThreeDShadow;
+                border-bottom: 0;
+                border-radius: 10px 10px 0 0;
+                background: ButtonFace;
+                color: ButtonText;
+                cursor: pointer;
+                box-shadow: 0 -1px 6px rgba(0, 0, 0, 0.22);
+            }
+            .ffne-dm-drawer-pull:hover {
+                filter: brightness(0.97);
+            }
+            .ffne-dm-drawer-pull:focus-visible {
+                outline: 2px solid Highlight;
+                outline-offset: 2px;
+            }
+            .ffne-dm-drawer-grabber {
+                width: 52px;
+                height: 4px;
+                border-radius: 999px;
+                background: currentColor;
+                opacity: 0.45;
+            }
+            .ffne-dm-drawer-chevron {
+                width: 10px;
+                height: 10px;
+                border-top: 2px solid currentColor;
+                border-left: 2px solid currentColor;
+                transform: rotate(45deg);
+                opacity: 0.72;
             }
             .ffne-dm-btn:disabled {
                 color: #777;

--- a/src/services/DocFetchService.ts
+++ b/src/services/DocFetchService.ts
@@ -6,6 +6,21 @@ import { Elements } from '../enums/Elements';
 import { SettingsManager } from '../modules/SettingsManager';
 import { fetchWithBackoff } from '../utils/fetchWithBackoff';
 
+interface SavePrivateDocOptions {
+    operationLabel: 'REFRESH' | 'IMPORT';
+    replacementHtml?: string;
+}
+
+interface TinyMceEditorLike {
+    setContent?: (html: string) => void;
+    save?: () => void;
+}
+
+interface TinyMceLike {
+    get?: (id: string) => TinyMceEditorLike | null;
+    activeEditor?: TinyMceEditorLike | null;
+}
+
 /**
  * Document fetch and refresh service for FFN private author documents.
  * Handles fetching doc pages, extracting content, and refreshing via hidden iframe.
@@ -79,34 +94,20 @@ export const DocFetchService = {
 
     /**
      * Refreshes a document by loading it in a hidden iframe and clicking Save.
-     * This lets FFN handle preserving the content - we just trigger the save action.
-     * Running in a hidden iframe means no popup window is needed, matching the
-     * background behaviour of the export functions.
-     *
-     * **SAFETY GUARDRAIL**: First checks if the document has content before proceeding.
-     * If the document is empty, we abort to prevent accidental data loss.
-     *
-     * @param docId - The internal FFN Document ID.
-     * @param title - The title of the document (for logging).
-     * @param attempt - (Internal) Current retry attempt number.
-     * @returns A promise resolving to true on success, false on failure.
+     * This lets FFN preserve the existing content while extending document life.
      */
     refreshPrivateDoc: async function (docId: string, title: string, attempt: number = 1): Promise<boolean> {
         const log = Core.getLogger(this.MODULE_NAME, 'refreshPrivateDoc');
-        const MAX_RETRIES = SettingsManager.get('fetchMaxRetries');
+        const maxRetries = SettingsManager.get('fetchMaxRetries');
 
         try {
-            log(`[REFRESH START] Attempting to refresh "${title}" (DocID: ${docId}, Attempt: ${attempt}/${MAX_RETRIES})`);
-
-            // ============================================================
-            // SAFETY GUARDRAIL: Check if document has content
-            // ============================================================
-            log(`[REFRESH] Verifying document has content...`);
+            log(`[REFRESH START] Attempting to refresh "${title}" (DocID: ${docId}, Attempt: ${attempt}/${maxRetries})`);
+            log('[REFRESH] Verifying document has content...');
 
             const doc = await fetchWithBackoff<Document>({
                 url: `https://www.fanfiction.net/docs/edit.php?docid=${docId}`,
-                maxRetries: SettingsManager.get('fetchMaxRetries'),
-                getDelay: (attempt) => attempt * SettingsManager.get('fetchRetryBaseMs'),
+                maxRetries,
+                getDelay: (retryAttempt) => retryAttempt * SettingsManager.get('fetchRetryBaseMs'),
                 onSuccess: async (resp) => {
                     const text = await resp.text();
                     return new DOMParser().parseFromString(text, 'text/html');
@@ -115,17 +116,14 @@ export const DocFetchService = {
                     log(`[REFRESH ERROR] Failed to fetch document for verification: ${resp.status}`);
                     return null;
                 },
-                onRetry: (attempt, waitTime) => {
-                    log(`[REFRESH] Verification fetch failed. Retrying in ${waitTime}ms... (Attempt ${attempt})`);
+                onRetry: (retryAttempt, waitTime) => {
+                    log(`[REFRESH] Verification fetch failed. Retrying in ${waitTime}ms... (Attempt ${retryAttempt})`);
                 },
             });
 
-            if (!doc) {
-                return false;
-            }
+            if (!doc) return false;
 
             const contentElement = Core.getElement(Elements.EDITOR_TEXT_AREA, doc);
-
             if (!contentElement) {
                 log(`[REFRESH ERROR] Could not find content textarea for "${title}"`);
                 return false;
@@ -134,199 +132,294 @@ export const DocFetchService = {
             const rawValue = (contentElement as HTMLTextAreaElement).value || contentElement.innerHTML;
             const trimmedContent = rawValue.trim();
 
-            // If content is empty or just whitespace, abort to prevent data loss
-            if (!trimmedContent || trimmedContent.length === 0) {
+            if (!trimmedContent) {
                 log(`[REFRESH BLOCKED] Document "${title}" appears to be empty. Aborting refresh to prevent data loss.`);
-                console.warn(`⚠️ REFRESH BLOCKED: Document "${title}" (DocID: ${docId}) has no content. Skipping to prevent accidental deletion.`);
+                console.warn(`REFRESH BLOCKED: Document "${title}" (DocID: ${docId}) has no content. Skipping to prevent accidental deletion.`);
                 return false;
             }
 
             log(`[REFRESH] Content verified (${trimmedContent.length} chars). Proceeding with refresh...`);
-
-            // ============================================================
-            // Proceed with refresh via hidden iframe (no popup required)
-            // ============================================================
-            log(`[REFRESH] Loading document in hidden iframe...`);
-
-            const saveSuccess = await new Promise<boolean>((resolve) => {
-                // Create a hidden, off-screen iframe so the save runs in the background.
-                // This avoids needing popup permissions while still performing a real
-                // browser form submission (sec-fetch-dest: "document").
-                const iframe = document.createElement('iframe');
-                iframe.name = `_ffn_refresh_${docId}`;
-                iframe.style.position = 'absolute';
-                iframe.style.width = '1px';
-                iframe.style.height = '1px';
-                iframe.style.left = '-9999px';
-                iframe.style.top = '-9999px';
-                iframe.style.border = 'none';
-                iframe.style.visibility = 'hidden';
-                document.body.appendChild(iframe);
-                iframe.src = `https://www.fanfiction.net/docs/edit.php?docid=${docId}`;
-
-                log(`[REFRESH] Hidden iframe created, waiting for page load...`);
-
-                // Helper: Cleans up the iframe from the DOM
-                const removeIframe = () => {
-                    clearPageHide();
-                    if (iframe.parentNode) {
-                        iframe.parentNode.removeChild(iframe);
-                    }
-                };
-
-                // Cleanup on page navigation to prevent detached DOM accumulation
-                const onPageHide = () => removeIframe();
-                window.addEventListener('pagehide', onPageHide);
-                const clearPageHide = () => window.removeEventListener('pagehide', onPageHide);
-
-                // Helper function to wait for the save button to appear in the iframe's DOM
-                const waitForSaveButton = (maxAttempts: number = 50): Promise<HTMLElement | null> => {
-                    return new Promise((resolveBtn) => {
-                        let attempts = 0;
-                        const checkForButton = setInterval(() => {
-                            attempts++;
-                            try {
-                                const iframeDoc = iframe.contentDocument;
-                                if (!iframeDoc) {
-                                    clearInterval(checkForButton);
-                                    resolveBtn(null);
-                                    return;
-                                }
-
-                                // Check if document has actual content (not just empty structure)
-                                const hasContent = iframeDoc.body && iframeDoc.body.children.length > 0;
-
-                                if (hasContent) {
-                                    const submitButton = Core.getElement(Elements.SAVE_BUTTON, iframeDoc);
-                                    if (submitButton) {
-                                        clearInterval(checkForButton);
-                                        log(`[REFRESH] Save button found after ${attempts * 200}ms`);
-                                        resolveBtn(submitButton);
-                                        return;
-                                    }
-                                }
-
-                                if (attempts >= maxAttempts) {
-                                    clearInterval(checkForButton);
-                                    log(`[REFRESH ERROR] Save button not found after ${maxAttempts * 200}ms`);
-                                    resolveBtn(null);
-                                }
-                            } catch (e) {
-                                clearInterval(checkForButton);
-                                log(`[REFRESH ERROR] Exception while waiting for button: ${e}`);
-                                resolveBtn(null);
-                            }
-                        }, 200);
-                    });
-                };
-
-                // Wait for iframe to reach complete state AND have content
-                const checkInterval = setInterval(async () => {
-                    try {
-                        const iframeDoc = iframe.contentDocument;
-                        // Check if iframe loaded and has the document
-                        if (iframeDoc && iframeDoc.readyState === 'complete') {
-                            clearInterval(checkInterval);
-
-                            try {
-                                log(`[REFRESH] Page readyState complete, waiting for content to load...`);
-
-                                // Wait for the save button to actually appear in the DOM
-                                const submitButton = await waitForSaveButton();
-
-                                if (!submitButton) {
-                                    log(`[REFRESH ERROR] Could not find Submit button in hidden iframe`);
-                                    removeIframe();
-                                    resolve(false);
-                                    return;
-                                }
-
-                                // Listen for page navigation (submit completion)
-                                let submitCompleted = false;
-                                const checkSubmit = setInterval(() => {
-                                    try {
-                                        const currentDoc = iframe.contentDocument;
-                                        // Check if page has reloaded (URL may change or readyState)
-                                        if (currentDoc && currentDoc.readyState === 'complete' && !submitCompleted) {
-                                            const successPanel = Core.getElement(Elements.SUCCESS_PANEL, currentDoc);
-                                            if (successPanel?.innerHTML.includes('successfully saved') || successPanel?.innerHTML.includes('Success')) {
-                                                submitCompleted = true;
-                                                clearInterval(checkSubmit);
-                                                log(`[REFRESH SUCCESS] Document saved successfully`);
-                                                console.log(`✓ REFRESH SUCCESS: Document ${docId} (${title}) saved successfully`);
-                                                setTimeout(removeIframe, 500);
-                                                resolve(true);
-                                            }
-                                        }
-                                    } catch (e) {
-                                        // iframe might be detached or navigated cross-origin
-                                        clearInterval(checkSubmit);
-                                    }
-                                }, 200);
-
-                                // Click the Save button (this triggers sec-fetch-dest: "document")
-                                // FFN will preserve the existing content when we submit without changes
-                                log(`[REFRESH] Clicking Save button...`);
-                                submitButton.click();
-
-                                // Timeout if no success after configured iframeSaveTimeoutMs
-                                const saveTimeout = SettingsManager.get('iframeSaveTimeoutMs');
-                                setTimeout(() => {
-                                    if (!submitCompleted) {
-                                        clearInterval(checkSubmit);
-                                        log(`[REFRESH TIMEOUT] No confirmation received after ${saveTimeout}ms`);
-                                        removeIframe();
-                                        resolve(false);
-                                    }
-                                }, saveTimeout);
-
-                            } catch (e) {
-                                log(`[REFRESH ERROR] Error manipulating iframe: ${e}`);
-                                removeIframe();
-                                resolve(false);
-                            }
-                        }
-                    } catch (e) {
-                        // Can't access iframe content (cross-origin or detached)
-                        clearInterval(checkInterval);
-                        log(`[REFRESH ERROR] Lost access to iframe: ${e}`);
-                        resolve(false);
-                    }
-                }, 100);
-
-                // Timeout if iframe doesn't load after configured iframeLoadTimeoutMs
-                const loadTimeout = SettingsManager.get('iframeLoadTimeoutMs');
-                setTimeout(() => {
-                    clearInterval(checkInterval);
-                    log(`[REFRESH TIMEOUT] Iframe didn't load after ${loadTimeout}ms`);
-                    removeIframe();
-                    resolve(false);
-                }, loadTimeout);
+            const saveSuccess = await this._savePrivateDocViaIframe(docId, title, {
+                operationLabel: 'REFRESH',
             });
 
-            // Retry with exponential backoff if failed
-            if (!saveSuccess && attempt < MAX_RETRIES) {
+            if (!saveSuccess && attempt < maxRetries) {
                 const waitTime = attempt * SettingsManager.get('fetchRetryBaseMs');
-                log(`[REFRESH] Refresh failed for "${title}". Retrying in ${waitTime}ms... (Attempt ${attempt + 1}/${MAX_RETRIES})`);
+                log(`[REFRESH] Refresh failed for "${title}". Retrying in ${waitTime}ms... (Attempt ${attempt + 1}/${maxRetries})`);
                 await new Promise(r => setTimeout(r, waitTime));
                 return this.refreshPrivateDoc(docId, title, attempt + 1);
             }
 
             return saveSuccess;
-
         } catch (err) {
-            log(`[REFRESH ERROR] Exception during refresh:`, err);
+            log('[REFRESH ERROR] Exception during refresh:', err);
             console.error(`REFRESH FAILED for document ${docId}:`, err);
 
-            // Retry with exponential backoff if failed
-            if (attempt < MAX_RETRIES) {
+            if (attempt < maxRetries) {
                 const waitTime = attempt * SettingsManager.get('fetchRetryBaseMs');
-                log(`[REFRESH] Exception occurred. Retrying in ${waitTime}ms... (Attempt ${attempt + 1}/${MAX_RETRIES})`);
+                log(`[REFRESH] Exception occurred. Retrying in ${waitTime}ms... (Attempt ${attempt + 1}/${maxRetries})`);
                 await new Promise(r => setTimeout(r, waitTime));
                 return this.refreshPrivateDoc(docId, title, attempt + 1);
             }
 
             return false;
         }
+    },
+
+    /**
+     * Replaces a private document's editor content with provided HTML, then saves.
+     * Used by DocManager bulk import after Markdown has been converted to HTML.
+     */
+    replacePrivateDocContent: async function (
+        docId: string,
+        title: string,
+        replacementHtml: string,
+        attempt: number = 1,
+    ): Promise<boolean> {
+        const log = Core.getLogger(this.MODULE_NAME, 'replacePrivateDocContent');
+        const maxRetries = SettingsManager.get('fetchMaxRetries');
+
+        if (!replacementHtml.trim()) {
+            log(`[IMPORT BLOCKED] Replacement content for "${title}" is empty.`);
+            return false;
+        }
+
+        try {
+            log(`[IMPORT START] Replacing "${title}" (DocID: ${docId}, Attempt: ${attempt}/${maxRetries})`);
+            const saveSuccess = await this._savePrivateDocViaIframe(docId, title, {
+                operationLabel: 'IMPORT',
+                replacementHtml,
+            });
+
+            if (!saveSuccess && attempt < maxRetries) {
+                const waitTime = attempt * SettingsManager.get('fetchRetryBaseMs');
+                log(`[IMPORT] Save failed for "${title}". Retrying in ${waitTime}ms... (Attempt ${attempt + 1}/${maxRetries})`);
+                await new Promise(r => setTimeout(r, waitTime));
+                return this.replacePrivateDocContent(docId, title, replacementHtml, attempt + 1);
+            }
+
+            return saveSuccess;
+        } catch (err) {
+            log('[IMPORT ERROR] Exception during import save:', err);
+            console.error(`IMPORT FAILED for document ${docId}:`, err);
+
+            if (attempt < maxRetries) {
+                const waitTime = attempt * SettingsManager.get('fetchRetryBaseMs');
+                log(`[IMPORT] Exception occurred. Retrying in ${waitTime}ms... (Attempt ${attempt + 1}/${maxRetries})`);
+                await new Promise(r => setTimeout(r, waitTime));
+                return this.replacePrivateDocContent(docId, title, replacementHtml, attempt + 1);
+            }
+
+            return false;
+        }
+    },
+
+    /**
+     * Shared hidden-iframe save implementation for refresh and import.
+     */
+    _savePrivateDocViaIframe: async function (
+        docId: string,
+        title: string,
+        options: SavePrivateDocOptions,
+    ): Promise<boolean> {
+        const log = Core.getLogger(this.MODULE_NAME, '_savePrivateDocViaIframe');
+        const label = options.operationLabel;
+
+        log(`[${label}] Loading document in hidden iframe...`);
+
+        return new Promise<boolean>((resolve) => {
+            const iframe = document.createElement('iframe');
+            iframe.name = `_ffn_${label.toLowerCase()}_${docId}`;
+            iframe.style.position = 'absolute';
+            iframe.style.width = '1px';
+            iframe.style.height = '1px';
+            iframe.style.left = '-9999px';
+            iframe.style.top = '-9999px';
+            iframe.style.border = 'none';
+            iframe.style.visibility = 'hidden';
+            document.body.appendChild(iframe);
+
+            let isResolved = false;
+            let checkInterval: number | null = null;
+            let loadTimer: number | null = null;
+            let saveTimer: number | null = null;
+            let submitInterval: number | null = null;
+
+            const clearTimer = (timerId: number | null, clearFn: (id: number) => void) => {
+                if (timerId !== null) clearFn(timerId);
+            };
+
+            const removeIframe = () => {
+                clearTimer(checkInterval, window.clearInterval);
+                clearTimer(loadTimer, window.clearTimeout);
+                clearTimer(saveTimer, window.clearTimeout);
+                clearTimer(submitInterval, window.clearInterval);
+                window.removeEventListener('pagehide', onPageHide);
+                if (iframe.parentNode) {
+                    iframe.parentNode.removeChild(iframe);
+                }
+            };
+
+            const resolveOnce = (value: boolean) => {
+                if (isResolved) return;
+                isResolved = true;
+                removeIframe();
+                resolve(value);
+            };
+
+            const onPageHide = () => resolveOnce(false);
+            window.addEventListener('pagehide', onPageHide);
+
+            const waitForSaveButton = (maxAttempts: number = 50): Promise<HTMLElement | null> => {
+                return new Promise((resolveBtn) => {
+                    let attempts = 0;
+                    const buttonInterval = window.setInterval(() => {
+                        attempts++;
+                        try {
+                            const iframeDoc = iframe.contentDocument;
+                            if (!iframeDoc) {
+                                window.clearInterval(buttonInterval);
+                                resolveBtn(null);
+                                return;
+                            }
+
+                            const hasContent = iframeDoc.body && iframeDoc.body.children.length > 0;
+                            if (hasContent) {
+                                const submitButton = Core.getElement(Elements.SAVE_BUTTON, iframeDoc);
+                                if (submitButton) {
+                                    window.clearInterval(buttonInterval);
+                                    log(`[${label}] Save button found after ${attempts * 200}ms`);
+                                    resolveBtn(submitButton);
+                                    return;
+                                }
+                            }
+
+                            if (attempts >= maxAttempts) {
+                                window.clearInterval(buttonInterval);
+                                log(`[${label} ERROR] Save button not found after ${maxAttempts * 200}ms`);
+                                resolveBtn(null);
+                            }
+                        } catch (e) {
+                            window.clearInterval(buttonInterval);
+                            log(`[${label} ERROR] Exception while waiting for button: ${e}`);
+                            resolveBtn(null);
+                        }
+                    }, 200);
+                });
+            };
+
+            checkInterval = window.setInterval(async () => {
+                try {
+                    const iframeDoc = iframe.contentDocument;
+                    if (!iframeDoc || iframeDoc.readyState !== 'complete') return;
+
+                    clearTimer(checkInterval, window.clearInterval);
+                    checkInterval = null;
+                    log(`[${label}] Page readyState complete, waiting for editor controls...`);
+
+                    const submitButton = await waitForSaveButton();
+                    if (!submitButton) {
+                        log(`[${label} ERROR] Could not find Submit button in hidden iframe`);
+                        resolveOnce(false);
+                        return;
+                    }
+
+                    if (options.replacementHtml !== undefined) {
+                        const didReplace = this._applyReplacementContent(iframe, options.replacementHtml);
+                        if (!didReplace) {
+                            log(`[${label} ERROR] Could not replace editor content for "${title}"`);
+                            resolveOnce(false);
+                            return;
+                        }
+                    }
+
+                    let submitCompleted = false;
+                    submitInterval = window.setInterval(() => {
+                        try {
+                            const currentDoc = iframe.contentDocument;
+                            if (currentDoc && currentDoc.readyState === 'complete' && !submitCompleted) {
+                                const successPanel = Core.getElement(Elements.SUCCESS_PANEL, currentDoc);
+                                if (successPanel?.innerHTML.includes('successfully saved') || successPanel?.innerHTML.includes('Success')) {
+                                    submitCompleted = true;
+                                    log(`[${label} SUCCESS] Document saved successfully`);
+                                    console.log(`${label} SUCCESS: Document ${docId} (${title}) saved successfully`);
+                                    resolveOnce(true);
+                                }
+                            }
+                        } catch {
+                            clearTimer(submitInterval, window.clearInterval);
+                            submitInterval = null;
+                        }
+                    }, 200);
+
+                    log(`[${label}] Clicking Save button...`);
+                    submitButton.click();
+
+                    const saveTimeout = SettingsManager.get('iframeSaveTimeoutMs');
+                    saveTimer = window.setTimeout(() => {
+                        if (!submitCompleted) {
+                            log(`[${label} TIMEOUT] No confirmation received after ${saveTimeout}ms`);
+                            resolveOnce(false);
+                        }
+                    }, saveTimeout);
+                } catch (e) {
+                    clearTimer(checkInterval, window.clearInterval);
+                    checkInterval = null;
+                    log(`[${label} ERROR] Lost access to iframe: ${e}`);
+                    resolveOnce(false);
+                }
+            }, 100);
+
+            const loadTimeout = SettingsManager.get('iframeLoadTimeoutMs');
+            loadTimer = window.setTimeout(() => {
+                log(`[${label} TIMEOUT] Iframe did not load after ${loadTimeout}ms`);
+                resolveOnce(false);
+            }, loadTimeout);
+
+            iframe.src = `https://www.fanfiction.net/docs/edit.php?docid=${docId}`;
+        });
+    },
+
+    /**
+     * Pushes replacement HTML into TinyMCE, its editor iframe, and the backing textarea.
+     */
+    _applyReplacementContent: function (iframe: HTMLIFrameElement, replacementHtml: string): boolean {
+        const log = Core.getLogger(this.MODULE_NAME, '_applyReplacementContent');
+        const iframeDoc = iframe.contentDocument;
+        if (!iframeDoc) return false;
+
+        const textarea = Core.getElement(Elements.EDITOR_TEXT_AREA, iframeDoc) as HTMLTextAreaElement | null;
+        if (!textarea) {
+            log('Backing textarea not found.');
+            return false;
+        }
+
+        const editorFrame = Core.getElement(Elements.EDITOR_TEXT_AREA_IFRAME, iframeDoc) as HTMLIFrameElement | null;
+        if (editorFrame?.contentDocument?.body) {
+            editorFrame.contentDocument.body.innerHTML = replacementHtml;
+        }
+
+        const iframeWindow = iframe.contentWindow as (Window & {
+            tinymce?: TinyMceLike;
+            tinyMCE?: TinyMceLike;
+        }) | null;
+        const tinyMce = iframeWindow?.tinymce || iframeWindow?.tinyMCE;
+        const editor = tinyMce?.get?.('bio') || tinyMce?.activeEditor || null;
+
+        if (editor?.setContent) {
+            editor.setContent(replacementHtml);
+        }
+
+        textarea.value = replacementHtml;
+        textarea.textContent = replacementHtml;
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+        textarea.dispatchEvent(new Event('change', { bubbles: true }));
+
+        if (editor?.save) {
+            editor.save();
+        }
+
+        const savedValue = textarea.value || textarea.textContent || '';
+        return savedValue.trim() === replacementHtml.trim();
     },
 };

--- a/src/services/DocFetchService.ts
+++ b/src/services/DocFetchService.ts
@@ -26,6 +26,11 @@ interface TinyMceLike {
     activeEditor?: TinyMceEditorLike | null;
 }
 
+interface HiddenEditorControls {
+    submitButton: HTMLElement;
+    textarea: HTMLTextAreaElement;
+}
+
 /**
  * Document fetch and refresh service for FFN private author documents.
  * Handles fetching doc pages, extracting content, and refreshing via hidden iframe.
@@ -102,11 +107,43 @@ export const DocFetchService = {
      * Returns null when the editor was not present, and trimmed content otherwise.
      */
     _getEditorContentForGuard: function (doc: Document): string | null {
-        const contentElement = Core.getElement(Elements.EDITOR_TEXT_AREA, doc) as HTMLTextAreaElement | null;
+        const contentElement = this._getEditorTextarea(doc);
         if (!contentElement) return null;
 
         const rawValue = contentElement.value || contentElement.innerHTML || '';
         return rawValue.trim();
+    },
+
+    /**
+     * Locates FFN's backing editor textarea across both private-doc editor variants.
+     */
+    _getEditorTextarea: function (doc: Document): HTMLTextAreaElement | null {
+        const directMatch = doc.querySelector<HTMLTextAreaElement>(
+            "textarea[name='bio'], textarea#bio, textarea[name='webcontent'], textarea#webcontent"
+        );
+        if (directMatch) return directMatch;
+
+        const textareas = Array.from(doc.querySelectorAll<HTMLTextAreaElement>('textarea'));
+        return textareas.length === 1 ? textareas[0] : null;
+    },
+
+    /**
+     * Locates the TinyMCE iframe associated with the backing editor textarea.
+     */
+    _getEditorIframe: function (doc: Document, textarea?: HTMLTextAreaElement): HTMLIFrameElement | null {
+        const selectors = ['#bio_ifr', '#webcontent_ifr'];
+        const editorKey = textarea?.id || textarea?.name;
+        if (editorKey && /^[A-Za-z0-9_-]+$/.test(editorKey)) {
+            selectors.unshift(`#${editorKey}_ifr`);
+        }
+
+        for (const selector of selectors) {
+            const frame = doc.querySelector<HTMLIFrameElement>(selector);
+            if (frame) return frame;
+        }
+
+        const editorFrames = Array.from(doc.querySelectorAll<HTMLIFrameElement>('iframe[id$="_ifr"]'));
+        return editorFrames.length === 1 ? editorFrames[0] : null;
     },
 
     /**
@@ -316,39 +353,51 @@ export const DocFetchService = {
             const onPageHide = () => failOnce('Page changed before the save confirmation was received.');
             window.addEventListener('pagehide', onPageHide);
 
-            const waitForSaveButton = (maxAttempts: number = 50): Promise<HTMLElement | null> => {
-                return new Promise((resolveBtn) => {
+            let editorControlsFailureReason = 'Editor controls were not ready in the hidden editor.';
+            const waitForEditorControls = (maxAttempts: number = 100): Promise<HiddenEditorControls | null> => {
+                return new Promise((resolveControls) => {
                     let attempts = 0;
-                    const buttonInterval = window.setInterval(() => {
+                    const controlsInterval = window.setInterval(() => {
                         attempts++;
                         try {
                             const iframeDoc = iframe.contentDocument;
                             if (!iframeDoc) {
-                                window.clearInterval(buttonInterval);
-                                resolveBtn(null);
+                                window.clearInterval(controlsInterval);
+                                editorControlsFailureReason = 'Hidden editor document was unavailable.';
+                                resolveControls(null);
                                 return;
                             }
 
                             const hasContent = iframeDoc.body && iframeDoc.body.children.length > 0;
                             if (hasContent) {
                                 const submitButton = Core.getElement(Elements.SAVE_BUTTON, iframeDoc);
-                                if (submitButton) {
-                                    window.clearInterval(buttonInterval);
-                                    log(`[${label}] Save button found after ${attempts * 200}ms`);
-                                    resolveBtn(submitButton);
+                                const textarea = this._getEditorTextarea(iframeDoc);
+                                if (submitButton && textarea) {
+                                    window.clearInterval(controlsInterval);
+                                    log(`[${label}] Editor controls found after ${attempts * 200}ms`);
+                                    resolveControls({ submitButton, textarea });
                                     return;
                                 }
                             }
 
                             if (attempts >= maxAttempts) {
-                                window.clearInterval(buttonInterval);
-                                log(`[${label} ERROR] Save button not found after ${maxAttempts * 200}ms`);
-                                resolveBtn(null);
+                                window.clearInterval(controlsInterval);
+                                const iframeDocForLog = iframe.contentDocument;
+                                const missingSaveButton = !iframeDocForLog || !Core.getElement(Elements.SAVE_BUTTON, iframeDocForLog);
+                                const missingTextarea = !iframeDocForLog || !this._getEditorTextarea(iframeDocForLog);
+                                const missing = [
+                                    missingSaveButton ? 'Save button' : '',
+                                    missingTextarea ? 'editor textarea' : '',
+                                ].filter(Boolean).join(' and ') || 'Editor controls';
+                                editorControlsFailureReason = `${missing} not found in the hidden editor after ${maxAttempts * 200}ms.`;
+                                log(`[${label} ERROR] ${missing} not found after ${maxAttempts * 200}ms`);
+                                resolveControls(null);
                             }
                         } catch (e) {
-                            window.clearInterval(buttonInterval);
-                            log(`[${label} ERROR] Exception while waiting for button: ${e}`);
-                            resolveBtn(null);
+                            window.clearInterval(controlsInterval);
+                            editorControlsFailureReason = `Could not inspect hidden editor controls: ${e}`;
+                            log(`[${label} ERROR] Exception while waiting for editor controls: ${e}`);
+                            resolveControls(null);
                         }
                     }, 200);
                 });
@@ -363,19 +412,15 @@ export const DocFetchService = {
                     checkInterval = null;
                     log(`[${label}] Page readyState complete, waiting for editor controls...`);
 
-                    const submitButton = await waitForSaveButton();
-                    if (!submitButton) {
-                        log(`[${label} ERROR] Could not find Submit button in hidden iframe`);
-                        failOnce('Save button was not found in the hidden editor.');
+                    const controls = await waitForEditorControls();
+                    if (!controls) {
+                        log(`[${label} ERROR] Could not find editor controls in hidden iframe`);
+                        failOnce(editorControlsFailureReason);
                         return;
                     }
 
-                    const currentContent = this._getEditorContentForGuard(iframeDoc);
-                    if (currentContent === null) {
-                        log(`[${label} ERROR] Could not find content textarea for "${title}" in hidden iframe`);
-                        failOnce('Editor textarea was not found in the hidden editor.');
-                        return;
-                    }
+                    const { submitButton, textarea } = controls;
+                    const currentContent = (textarea.value || textarea.innerHTML || '').trim();
 
                     if (label === 'REFRESH' && !currentContent) {
                         log(`[${label} BLOCKED] Hidden editor loaded empty content for "${title}". Save blocked.`);
@@ -447,13 +492,13 @@ export const DocFetchService = {
         const iframeDoc = iframe.contentDocument;
         if (!iframeDoc) return false;
 
-        const textarea = Core.getElement(Elements.EDITOR_TEXT_AREA, iframeDoc) as HTMLTextAreaElement | null;
+        const textarea = this._getEditorTextarea(iframeDoc);
         if (!textarea) {
             log('Backing textarea not found.');
             return false;
         }
 
-        const editorFrame = Core.getElement(Elements.EDITOR_TEXT_AREA_IFRAME, iframeDoc) as HTMLIFrameElement | null;
+        const editorFrame = this._getEditorIframe(iframeDoc, textarea);
         if (editorFrame?.contentDocument?.body) {
             editorFrame.contentDocument.body.innerHTML = replacementHtml;
         }
@@ -463,7 +508,8 @@ export const DocFetchService = {
             tinyMCE?: TinyMceLike;
         }) | null;
         const tinyMce = iframeWindow?.tinymce || iframeWindow?.tinyMCE;
-        const editor = tinyMce?.get?.('bio') || tinyMce?.activeEditor || null;
+        const editorKey = textarea.id || textarea.name || 'bio';
+        const editor = tinyMce?.get?.(editorKey) || tinyMce?.get?.('bio') || tinyMce?.get?.('webcontent') || tinyMce?.activeEditor || null;
 
         if (editor?.setContent) {
             editor.setContent(replacementHtml);

--- a/src/services/DocFetchService.ts
+++ b/src/services/DocFetchService.ts
@@ -11,6 +11,11 @@ interface SavePrivateDocOptions {
     replacementHtml?: string;
 }
 
+export interface PrivateDocSaveResult {
+    ok: boolean;
+    reason?: string;
+}
+
 interface TinyMceEditorLike {
     setContent?: (html: string) => void;
     save?: () => void;
@@ -93,6 +98,18 @@ export const DocFetchService = {
     },
 
     /**
+     * Reads the backing editor textarea used by FFN private documents.
+     * Returns null when the editor was not present, and trimmed content otherwise.
+     */
+    _getEditorContentForGuard: function (doc: Document): string | null {
+        const contentElement = Core.getElement(Elements.EDITOR_TEXT_AREA, doc) as HTMLTextAreaElement | null;
+        if (!contentElement) return null;
+
+        const rawValue = contentElement.value || contentElement.innerHTML || '';
+        return rawValue.trim();
+    },
+
+    /**
      * Refreshes a document by loading it in a hidden iframe and clicking Save.
      * This lets FFN preserve the existing content while extending document life.
      */
@@ -123,14 +140,11 @@ export const DocFetchService = {
 
             if (!doc) return false;
 
-            const contentElement = Core.getElement(Elements.EDITOR_TEXT_AREA, doc);
-            if (!contentElement) {
+            const trimmedContent = this._getEditorContentForGuard(doc);
+            if (trimmedContent === null) {
                 log(`[REFRESH ERROR] Could not find content textarea for "${title}"`);
                 return false;
             }
-
-            const rawValue = (contentElement as HTMLTextAreaElement).value || contentElement.innerHTML;
-            const trimmedContent = rawValue.trim();
 
             if (!trimmedContent) {
                 log(`[REFRESH BLOCKED] Document "${title}" appears to be empty. Aborting refresh to prevent data loss.`);
@@ -176,29 +190,43 @@ export const DocFetchService = {
         replacementHtml: string,
         attempt: number = 1,
     ): Promise<boolean> {
+        const result = await this.replacePrivateDocContentWithResult(docId, title, replacementHtml, attempt);
+        return result.ok;
+    },
+
+    /**
+     * Replaces private document content and returns a user-facing failure reason
+     * when the operation cannot be completed.
+     */
+    replacePrivateDocContentWithResult: async function (
+        docId: string,
+        title: string,
+        replacementHtml: string,
+        attempt: number = 1,
+    ): Promise<PrivateDocSaveResult> {
         const log = Core.getLogger(this.MODULE_NAME, 'replacePrivateDocContent');
         const maxRetries = SettingsManager.get('fetchMaxRetries');
 
         if (!replacementHtml.trim()) {
             log(`[IMPORT BLOCKED] Replacement content for "${title}" is empty.`);
-            return false;
+            return { ok: false, reason: 'Replacement content is empty.' };
         }
 
         try {
             log(`[IMPORT START] Replacing "${title}" (DocID: ${docId}, Attempt: ${attempt}/${maxRetries})`);
-            const saveSuccess = await this._savePrivateDocViaIframe(docId, title, {
+            const saveResult = await this._savePrivateDocViaIframeWithResult(docId, title, {
                 operationLabel: 'IMPORT',
                 replacementHtml,
             });
 
-            if (!saveSuccess && attempt < maxRetries) {
+            if (!saveResult.ok && attempt < maxRetries) {
                 const waitTime = attempt * SettingsManager.get('fetchRetryBaseMs');
                 log(`[IMPORT] Save failed for "${title}". Retrying in ${waitTime}ms... (Attempt ${attempt + 1}/${maxRetries})`);
                 await new Promise(r => setTimeout(r, waitTime));
-                return this.replacePrivateDocContent(docId, title, replacementHtml, attempt + 1);
+                return this.replacePrivateDocContentWithResult(docId, title, replacementHtml, attempt + 1);
             }
 
-            return saveSuccess;
+            return saveResult;
         } catch (err) {
             log('[IMPORT ERROR] Exception during import save:', err);
             console.error(`IMPORT FAILED for document ${docId}:`, err);
@@ -207,10 +235,11 @@ export const DocFetchService = {
                 const waitTime = attempt * SettingsManager.get('fetchRetryBaseMs');
                 log(`[IMPORT] Exception occurred. Retrying in ${waitTime}ms... (Attempt ${attempt + 1}/${maxRetries})`);
                 await new Promise(r => setTimeout(r, waitTime));
-                return this.replacePrivateDocContent(docId, title, replacementHtml, attempt + 1);
+                return this.replacePrivateDocContentWithResult(docId, title, replacementHtml, attempt + 1);
             }
 
-            return false;
+            const message = err instanceof Error ? err.message : String(err);
+            return { ok: false, reason: `Unexpected error: ${message}` };
         }
     },
 
@@ -222,12 +251,28 @@ export const DocFetchService = {
         title: string,
         options: SavePrivateDocOptions,
     ): Promise<boolean> {
+        const result = await this._savePrivateDocViaIframeWithResult(docId, title, options);
+        return result.ok;
+    },
+
+    /**
+     * Shared hidden-iframe save implementation with a structured failure reason.
+     */
+    _savePrivateDocViaIframeWithResult: async function (
+        docId: string,
+        title: string,
+        options: SavePrivateDocOptions,
+    ): Promise<PrivateDocSaveResult> {
         const log = Core.getLogger(this.MODULE_NAME, '_savePrivateDocViaIframe');
         const label = options.operationLabel;
 
         log(`[${label}] Loading document in hidden iframe...`);
 
-        return new Promise<boolean>((resolve) => {
+        if (options.replacementHtml !== undefined && !options.replacementHtml.trim()) {
+            return { ok: false, reason: 'Replacement content is empty.' };
+        }
+
+        return new Promise<PrivateDocSaveResult>((resolve) => {
             const iframe = document.createElement('iframe');
             iframe.name = `_ffn_${label.toLowerCase()}_${docId}`;
             iframe.style.position = 'absolute';
@@ -260,14 +305,15 @@ export const DocFetchService = {
                 }
             };
 
-            const resolveOnce = (value: boolean) => {
+            const resolveOnce = (result: PrivateDocSaveResult) => {
                 if (isResolved) return;
                 isResolved = true;
                 removeIframe();
-                resolve(value);
+                resolve(result);
             };
 
-            const onPageHide = () => resolveOnce(false);
+            const failOnce = (reason: string) => resolveOnce({ ok: false, reason });
+            const onPageHide = () => failOnce('Page changed before the save confirmation was received.');
             window.addEventListener('pagehide', onPageHide);
 
             const waitForSaveButton = (maxAttempts: number = 50): Promise<HTMLElement | null> => {
@@ -320,7 +366,20 @@ export const DocFetchService = {
                     const submitButton = await waitForSaveButton();
                     if (!submitButton) {
                         log(`[${label} ERROR] Could not find Submit button in hidden iframe`);
-                        resolveOnce(false);
+                        failOnce('Save button was not found in the hidden editor.');
+                        return;
+                    }
+
+                    const currentContent = this._getEditorContentForGuard(iframeDoc);
+                    if (currentContent === null) {
+                        log(`[${label} ERROR] Could not find content textarea for "${title}" in hidden iframe`);
+                        failOnce('Editor textarea was not found in the hidden editor.');
+                        return;
+                    }
+
+                    if (label === 'REFRESH' && !currentContent) {
+                        log(`[${label} BLOCKED] Hidden editor loaded empty content for "${title}". Save blocked.`);
+                        failOnce('Hidden editor loaded empty content, so save was blocked.');
                         return;
                     }
 
@@ -328,7 +387,7 @@ export const DocFetchService = {
                         const didReplace = this._applyReplacementContent(iframe, options.replacementHtml);
                         if (!didReplace) {
                             log(`[${label} ERROR] Could not replace editor content for "${title}"`);
-                            resolveOnce(false);
+                            failOnce('Replacement content could not be written into the hidden editor.');
                             return;
                         }
                     }
@@ -343,7 +402,7 @@ export const DocFetchService = {
                                     submitCompleted = true;
                                     log(`[${label} SUCCESS] Document saved successfully`);
                                     console.log(`${label} SUCCESS: Document ${docId} (${title}) saved successfully`);
-                                    resolveOnce(true);
+                                    resolveOnce({ ok: true });
                                 }
                             }
                         } catch {
@@ -359,21 +418,21 @@ export const DocFetchService = {
                     saveTimer = window.setTimeout(() => {
                         if (!submitCompleted) {
                             log(`[${label} TIMEOUT] No confirmation received after ${saveTimeout}ms`);
-                            resolveOnce(false);
+                            failOnce(`No save confirmation appeared within ${saveTimeout}ms.`);
                         }
                     }, saveTimeout);
                 } catch (e) {
                     clearTimer(checkInterval, window.clearInterval);
                     checkInterval = null;
                     log(`[${label} ERROR] Lost access to iframe: ${e}`);
-                    resolveOnce(false);
+                    failOnce(`Lost access to the hidden editor: ${e}`);
                 }
             }, 100);
 
             const loadTimeout = SettingsManager.get('iframeLoadTimeoutMs');
             loadTimer = window.setTimeout(() => {
                 log(`[${label} TIMEOUT] Iframe did not load after ${loadTimeout}ms`);
-                resolveOnce(false);
+                failOnce(`Hidden editor did not load within ${loadTimeout}ms.`);
             }, loadTimeout);
 
             iframe.src = `https://www.fanfiction.net/docs/edit.php?docid=${docId}`;


### PR DESCRIPTION
This pull request significantly expands and improves test coverage for the `DocManager` module, especially around bulk import and advanced UI features. It also introduces several new test helpers for easier test setup, enhances the bulk operation interface, and updates editor element selectors to support additional editor variants.

**Test suite expansion and improvements:**

- Added comprehensive tests for `DocManager` covering bulk import planning, modal UI, file conversion/sanitization, and the advanced drawer, including edge cases like duplicate filenames and blocked file types.
- Introduced new test helpers (`makeItem`, `makeFile`, `makeSelectedFile`) to streamline creation of test data for bulk operations.
- Added tests for `DocFetchService` to verify editor content extraction logic for different textarea variants and missing editors.

**Bulk operation enhancements:**

- Extended the `IBulkItem` interface to include `docName`, improving clarity and matching logic in bulk operations.
- Added an optional `onItemStart` callback to `IBulkOperationConfig` for more granular progress tracking during bulk operations.

**Editor element selection improvements:**

- Updated selectors in `GlobalDelegate` to support both `bio` and `webcontent` textareas and iframes, increasing compatibility with different editor configurations.