### PR TITLE
Feat/bulk replace

### DIFF
--- a/src/__tests__/SettingsManager.test.ts
+++ b/src/__tests__/SettingsManager.test.ts
@@ -124,6 +124,7 @@ describe('_parseStoredValue — edge cases', () => {
             'pasteForceIntercept',
             'ao3HtmlCompatibility',
             'appendSeparator',
+            'bulkReplaceAutofill',
         ];
         for (const k of boolKeys) {
             expect(_parseStoredValue(k, true)).toBe(true);

--- a/src/__tests__/SettingsPage.test.ts
+++ b/src/__tests__/SettingsPage.test.ts
@@ -1,7 +1,12 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SettingsPage } from '../modules/SettingsPage';
+import { SettingsManager } from '../modules/SettingsManager';
 
 describe('SettingsPage', () => {
+    beforeEach(() => {
+        SettingsManager.prime();
+    });
+
     afterEach(() => {
         SettingsPage.closeModal();
         document.body.innerHTML = '';

--- a/src/__tests__/SettingsPage.test.ts
+++ b/src/__tests__/SettingsPage.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { SettingsPage } from '../modules/SettingsPage';
+
+describe('SettingsPage', () => {
+    afterEach(() => {
+        SettingsPage.closeModal();
+        document.body.innerHTML = '';
+        document.head.innerHTML = '';
+    });
+
+    it('shows the Bulk Replace autofill toggle', () => {
+        SettingsPage.openModal();
+
+        const toggle = document.querySelector<HTMLInputElement>('[data-setting="bulkReplaceAutofill"]');
+
+        expect(document.body.textContent).toContain('Autofill in Bulk Replace');
+        expect(toggle).not.toBeNull();
+        expect(toggle?.type).toBe('checkbox');
+        expect(toggle?.checked).toBe(true);
+    });
+});

--- a/src/__tests__/StoryEditContent.test.ts
+++ b/src/__tests__/StoryEditContent.test.ts
@@ -103,15 +103,19 @@ describe('StoryEditContent parsing', () => {
 describe('StoryEditContent mapping state', () => {
     it('tracks manual mappings and skips unmapped rows', () => {
         const mappings = makeMappings(3);
-        const docs = makeDocs('StoryName', 1, 3);
+        const docs = [
+            { docId: 'plain-1', docName: 'Standalone Intro' },
+            { docId: 'plain-2', docName: 'Standalone Middle' },
+            { docId: 'plain-3', docName: 'Standalone Finale' },
+        ];
 
-        StoryEditContent._setManualDocSelection(mappings, docs, 0, 'StoryName-1');
+        StoryEditContent._setManualDocSelection(mappings, docs, 0, 'plain-1');
         const plan = StoryEditContent._buildMappingPlan(mappings);
 
         expect(plan.mappedCount).toBe(1);
         expect(plan.skippedCount).toBe(2);
         expect(plan.rows[0]).toMatchObject({
-            selectedDocName: 'StoryName001',
+            selectedDocName: 'Standalone Intro',
             source: 'manual',
             status: 'mapped',
         });

--- a/src/__tests__/StoryEditContent.test.ts
+++ b/src/__tests__/StoryEditContent.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { StoryEditContent } from '../modules/StoryEditContent';
 import { DocFetchService } from '../services/DocFetchService';
 import { StoryReplaceService } from '../services/StoryReplaceService';
+import { Core } from '../modules/Core';
+import { StoryEditContentDelegate } from '../delegates/StoryEditContentDelegate';
 import type {
     IStoryEditContentChapter,
     IStoryEditContentDoc,
@@ -209,6 +211,44 @@ describe('StoryEditContent mapping state', () => {
         expect(plan.hasBlockingErrors).toBe(true);
         expect(plan.duplicateDocIds).toEqual(['StoryName-1']);
         expect(plan.rows.map(row => row.status)).toEqual(['duplicate', 'duplicate']);
+    });
+});
+
+describe('StoryEditContent injection', () => {
+    beforeEach(() => {
+        cleanupDOM();
+        Core.activeDelegate = StoryEditContentDelegate;
+    });
+
+    afterEach(() => {
+        Core.activeDelegate = null;
+        cleanupDOM();
+    });
+
+    it('places Bulk Replace next to the visible Replace/Update Chapter toggle', () => {
+        document.body.innerHTML = `
+            <center>
+                <a href="#">Post New Chapter</a> |
+                <a href="#">Replace/Update Chapter</a>
+            </center>
+            <div id="area_modchapter" style="display:none;">
+                <form id="replacechapter">
+                    <select name="storytextid"></select>
+                    <select name="docid"></select>
+                    <input type="hidden" name="action" value="replace">
+                    <button type="submit">Replace Chapter Content with Document</button>
+                </form>
+            </div>
+        `;
+
+        StoryEditContent.injectBulkReplaceButton(document.getElementById('replacechapter') as HTMLFormElement);
+
+        const button = document.getElementById('ffne-story-bulk-replace-btn');
+        const visibleControls = document.querySelector('center');
+
+        expect(button).not.toBeNull();
+        expect(button?.parentElement).toBe(visibleControls);
+        expect(document.querySelector('#area_modchapter #ffne-story-bulk-replace-btn')).toBeNull();
     });
 });
 

--- a/src/__tests__/StoryEditContent.test.ts
+++ b/src/__tests__/StoryEditContent.test.ts
@@ -106,6 +106,14 @@ describe('StoryEditContent parsing', () => {
 });
 
 describe('StoryEditContent mapping state', () => {
+    beforeEach(() => {
+        vi.spyOn(SettingsManager, 'get').mockReturnValue(true);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
     it('tracks manual mappings and skips unmapped rows', () => {
         const mappings = makeMappings(3);
         const docs = [
@@ -171,22 +179,18 @@ describe('StoryEditContent mapping state', () => {
     it('does not autofill when Bulk Replace autofill is disabled', () => {
         const mappings = makeMappings(4);
         const docs = makeDocs('StoryName', 1, 4);
-        const getSpy = vi.spyOn(SettingsManager, 'get').mockReturnValue(false);
+        vi.mocked(SettingsManager.get).mockReturnValue(false);
 
-        try {
-            StoryEditContent._setManualDocSelection(mappings, docs, 1, 'StoryName-2');
+        StoryEditContent._setManualDocSelection(mappings, docs, 1, 'StoryName-2');
 
-            expect(mappings.map(row => row.selectedDocName)).toEqual([
-                '',
-                'StoryName002',
-                '',
-                '',
-            ]);
-            expect(mappings[1].source).toBe('manual');
-            expect(mappings.some(row => row.source === 'autofill')).toBe(false);
-        } finally {
-            getSpy.mockRestore();
-        }
+        expect(mappings.map(row => row.selectedDocName)).toEqual([
+            '',
+            'StoryName002',
+            '',
+            '',
+        ]);
+        expect(mappings[1].source).toBe('manual');
+        expect(mappings.some(row => row.source === 'autofill')).toBe(false);
     });
 
     it('autofilled rows do not cascade new autofill chains', () => {
@@ -398,7 +402,7 @@ describe('StoryEditContent bulk replace execution', () => {
     });
 });
 
-describe('StoryReplaceService hidden page submitter', () => {
+describe('StoryReplaceService hidden iframe submitter', () => {
     beforeEach(() => {
         cleanupDOM();
         vi.useFakeTimers();
@@ -418,61 +422,36 @@ describe('StoryReplaceService hidden page submitter', () => {
         doc.close();
     }
 
-    it('loads StoryEditContent in a hidden iframe and submits its native replace form', async () => {
-        const promise = StoryReplaceService.submitReplaceForm('/story/story_edit_content.php?storyid=1', '101', '201');
-        const frame = document.querySelector('iframe') as HTMLIFrameElement;
-
-        expect(frame).not.toBeNull();
-        expect(frame.src).toBe('http://localhost:3000/story/story_edit_content.php?storyid=1');
-
-        writeFrameHtml(frame, `
-            <form id="replacechapter" method="post" action="?storyid=1">
-                <select name="storytextid">
-                    <option value="101">1. Chapter</option>
-                </select>
-                <select name="docid">
-                    <option value="201">StoryName001</option>
-                </select>
-                <input type="hidden" name="action" value="replace">
-            </form>
-        `);
-        const form = frame.contentDocument?.querySelector('form') as HTMLFormElement;
-        const submitSpy = vi.fn(function (this: HTMLFormElement) {
-            expect(this.ownerDocument).toBe(frame.contentDocument);
-            expect((this.elements.namedItem('storytextid') as HTMLSelectElement).value).toBe('101');
-            expect((this.elements.namedItem('docid') as HTMLSelectElement).value).toBe('201');
+    it('posts an isolated replace form to a hidden iframe target', async () => {
+        const submitSpy = vi.spyOn(HTMLFormElement.prototype, 'submit').mockImplementation(function (this: HTMLFormElement) {
+            const frame = document.querySelector(`iframe[name="${this.target}"]`) as HTMLIFrameElement;
+            expect(frame).not.toBeNull();
+            expect(this.method).toBe('post');
+            expect(this.action).toBe('http://localhost:3000/story/story_edit_content.php?storyid=1');
+            expect((this.elements.namedItem('storytextid') as HTMLInputElement).value).toBe('101');
+            expect((this.elements.namedItem('docid') as HTMLInputElement).value).toBe('201');
             expect((this.elements.namedItem('action') as HTMLInputElement).value).toBe('replace');
 
             writeFrameHtml(frame, '<div class="panel_success">Success</div>');
             frame.dispatchEvent(new Event('load'));
         });
-        Object.defineProperty(form, 'submit', { value: submitSpy, configurable: true });
-        frame.dispatchEvent(new Event('load'));
+
+        const promise = StoryReplaceService.submitReplaceForm('/story/story_edit_content.php?storyid=1', '101', '201');
 
         await expect(promise).resolves.toEqual({ ok: true });
         expect(submitSpy).toHaveBeenCalledTimes(1);
         expect(document.querySelector('iframe')).toBeNull();
+        expect(document.querySelector('form[target^="ffne_story_replace_"]')).toBeNull();
     });
 
     it('returns a page error from the hidden replace response', async () => {
-        const promise = StoryReplaceService.submitReplaceForm('/story/story_edit_content.php?storyid=1', '101', '201');
-        const frame = document.querySelector('iframe') as HTMLIFrameElement;
-        writeFrameHtml(frame, `
-            <form id="replacechapter">
-                <select name="storytextid"><option value="101">1</option></select>
-                <select name="docid"><option value="201">Doc</option></select>
-                <input name="action" value="replace">
-            </form>
-        `);
-        const form = frame.contentDocument?.querySelector('form') as HTMLFormElement;
-        Object.defineProperty(form, 'submit', {
-            configurable: true,
-            value: vi.fn(() => {
-                writeFrameHtml(frame, '<div class="panel_error">No permission.</div>');
-                frame.dispatchEvent(new Event('load'));
-            }),
+        vi.spyOn(HTMLFormElement.prototype, 'submit').mockImplementation(function (this: HTMLFormElement) {
+            const frame = document.querySelector(`iframe[name="${this.target}"]`) as HTMLIFrameElement;
+            writeFrameHtml(frame, '<div id="replace_err"></div><div class="panel_error">No permission.</div>');
+            frame.dispatchEvent(new Event('load'));
         });
-        frame.dispatchEvent(new Event('load'));
+
+        const promise = StoryReplaceService.submitReplaceForm('/story/story_edit_content.php?storyid=1', '101', '201');
 
         await expect(promise).resolves.toEqual({ ok: false, reason: 'No permission.' });
     });

--- a/src/__tests__/StoryEditContent.test.ts
+++ b/src/__tests__/StoryEditContent.test.ts
@@ -1,0 +1,333 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { StoryEditContent } from '../modules/StoryEditContent';
+import { DocFetchService } from '../services/DocFetchService';
+import type {
+    IStoryEditContentChapter,
+    IStoryEditContentDoc,
+    IStoryEditContentMappingRow,
+} from '../interfaces/IStoryEditContent';
+
+function cleanupDOM(): void {
+    document.body.innerHTML = '';
+    document.head.innerHTML = '';
+}
+
+function makeBtn(): HTMLButtonElement {
+    const btn = document.createElement('button');
+    btn.innerText = 'Run Bulk Replace';
+    document.body.appendChild(btn);
+    return btn;
+}
+
+function mockEvent(btn: HTMLButtonElement): MouseEvent {
+    return { currentTarget: btn } as unknown as MouseEvent;
+}
+
+function makeChapter(chapterNumber: number): IStoryEditContentChapter {
+    return {
+        storyTextId: String(1000 + chapterNumber),
+        chapterNumber,
+        chapterLabel: `Chapter ${chapterNumber}`,
+        published: true,
+        row: null,
+    };
+}
+
+function makeDocs(prefix: string, start: number, end: number): IStoryEditContentDoc[] {
+    const docs: IStoryEditContentDoc[] = [];
+    for (let current = start; current <= end; current++) {
+        docs.push({
+            docId: `${prefix}-${current}`,
+            docName: `${prefix}${String(current).padStart(3, '0')}`,
+        });
+    }
+    return docs;
+}
+
+function makeMappings(chapterCount: number): IStoryEditContentMappingRow[] {
+    return StoryEditContent._createMappingRows(
+        Array.from({ length: chapterCount }, (_value, index) => makeChapter(index + 1))
+    );
+}
+
+describe('StoryEditContent parsing', () => {
+    beforeEach(() => {
+        cleanupDOM();
+    });
+
+    afterEach(() => {
+        cleanupDOM();
+    });
+
+    it('parses published chapters and document options from FFN-like HTML', () => {
+        document.body.innerHTML = `
+            <form action="/story/story_edit_content.php">
+                <input type="hidden" name="action" value="replace">
+                <select name="storytextid">
+                    <option value="">Select Chapter</option>
+                    <option value="101">Chapter 1 - One</option>
+                    <option value="102">Chapter 2 - Two</option>
+                    <option value="103">Chapter 3 - Three</option>
+                </select>
+                <select name="docid">
+                    <option value="">Select Doc</option>
+                    <option value="201">StoryName001</option>
+                    <option value="202">StoryName002</option>
+                </select>
+                <input type="submit" value="Replace">
+            </form>
+            <table>
+                <tbody>
+                    <tr data-storytextid="101"><td>Chapter 1</td><td>Published</td></tr>
+                    <tr data-storytextid="102"><td>Chapter 2</td><td>Draft</td></tr>
+                    <tr data-storytextid="103"><td>Chapter 3</td><td>Published</td></tr>
+                </tbody>
+            </table>
+        `;
+
+        const chapters = StoryEditContent._parsePublishedChapters(
+            document.querySelector('select[name="storytextid"]'),
+            Array.from(document.querySelectorAll('tbody tr')),
+        );
+        const docs = StoryEditContent._parseDocOptions(document.querySelector('select[name="docid"]'));
+
+        expect(chapters.map(chapter => chapter.storyTextId)).toEqual(['101', '103']);
+        expect(chapters.map(chapter => chapter.chapterNumber)).toEqual([1, 3]);
+        expect(docs).toEqual([
+            { docId: '201', docName: 'StoryName001' },
+            { docId: '202', docName: 'StoryName002' },
+        ]);
+    });
+});
+
+describe('StoryEditContent mapping state', () => {
+    it('tracks manual mappings and skips unmapped rows', () => {
+        const mappings = makeMappings(3);
+        const docs = makeDocs('StoryName', 1, 3);
+
+        StoryEditContent._setManualDocSelection(mappings, docs, 0, 'StoryName-1');
+        const plan = StoryEditContent._buildMappingPlan(mappings);
+
+        expect(plan.mappedCount).toBe(1);
+        expect(plan.skippedCount).toBe(2);
+        expect(plan.rows[0]).toMatchObject({
+            selectedDocName: 'StoryName001',
+            source: 'manual',
+            status: 'mapped',
+        });
+        expect(plan.rows[1].status).toBe('skipped');
+        expect(plan.rows[2].status).toBe('skipped');
+    });
+
+    it('autofills backward and forward from a middle selection with zero padding', () => {
+        const mappings = makeMappings(7);
+        const docs = makeDocs('StoryName', 1, 7);
+
+        StoryEditContent._setManualDocSelection(mappings, docs, 4, 'StoryName-5');
+
+        expect(mappings.map(row => row.selectedDocName)).toEqual([
+            'StoryName001',
+            'StoryName002',
+            'StoryName003',
+            'StoryName004',
+            'StoryName005',
+            'StoryName006',
+            'StoryName007',
+        ]);
+        expect(mappings[0].source).toBe('autofill');
+        expect(mappings[4].source).toBe('manual');
+        expect(mappings[6].source).toBe('autofill');
+    });
+
+    it('does not autofill rows more than once after they were autofilled', () => {
+        const mappings = makeMappings(4);
+        const docs = [
+            ...makeDocs('StoryName', 1, 4),
+            ...makeDocs('AltName', 1, 4),
+        ];
+
+        StoryEditContent._setManualDocSelection(mappings, docs, 1, 'StoryName-2');
+        StoryEditContent._setManualDocSelection(mappings, docs, 2, 'AltName-3');
+
+        expect(mappings.map(row => row.selectedDocName)).toEqual([
+            'StoryName001',
+            'StoryName002',
+            'AltName003',
+            'StoryName004',
+        ]);
+        expect(mappings[0].hasBeenAutofilled).toBe(true);
+        expect(mappings[3].hasBeenAutofilled).toBe(true);
+    });
+
+    it('autofilled rows do not cascade new autofill chains', () => {
+        const mappings = makeMappings(4);
+        const docs = makeDocs('StoryName', 2, 4);
+
+        StoryEditContent._setManualDocSelection(mappings, docs, 1, 'StoryName-2');
+
+        expect(mappings.map(row => row.selectedDocName)).toEqual([
+            '',
+            'StoryName002',
+            'StoryName003',
+            'StoryName004',
+        ]);
+        expect(mappings[0].source).toBe('unmapped');
+    });
+
+    it('manual selections override earlier autofill', () => {
+        const mappings = makeMappings(4);
+        const docs = [
+            ...makeDocs('StoryName', 1, 4),
+            ...makeDocs('AltName', 1, 4),
+        ];
+
+        StoryEditContent._setManualDocSelection(mappings, docs, 1, 'StoryName-2');
+        StoryEditContent._setManualDocSelection(mappings, docs, 0, 'AltName-1');
+        StoryEditContent._setManualDocSelection(mappings, docs, 2, 'AltName-3');
+
+        expect(mappings[0]).toMatchObject({
+            selectedDocName: 'AltName001',
+            source: 'manual',
+        });
+        expect(mappings[1].selectedDocName).toBe('StoryName002');
+        expect(mappings[3].selectedDocName).toBe('StoryName004');
+    });
+
+    it('blocks duplicate doc mappings during validation', () => {
+        const mappings = makeMappings(2);
+        const docs = makeDocs('StoryName', 1, 2);
+
+        StoryEditContent._setManualDocSelection(mappings, docs, 0, 'StoryName-1');
+        StoryEditContent._setManualDocSelection(mappings, docs, 1, 'StoryName-1');
+        const plan = StoryEditContent._buildMappingPlan(mappings);
+
+        expect(plan.hasBlockingErrors).toBe(true);
+        expect(plan.duplicateDocIds).toEqual(['StoryName-1']);
+        expect(plan.rows.map(row => row.status)).toEqual(['duplicate', 'duplicate']);
+    });
+});
+
+describe('StoryEditContent bulk replace execution', () => {
+    beforeEach(() => {
+        cleanupDOM();
+        vi.useFakeTimers();
+        vi.restoreAllMocks();
+        vi.stubGlobal('fetch', vi.fn());
+    });
+
+    afterEach(() => {
+        StoryEditContent._state = null;
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+        cleanupDOM();
+    });
+
+    async function runBulkReplaceWithState(mappings: IStoryEditContentMappingRow[], docs: IStoryEditContentDoc[]) {
+        const btn = makeBtn();
+        const status = document.createElement('div');
+        const results = document.createElement('div');
+        document.body.append(status, results);
+
+        StoryEditContent._state = {
+            actionUrl: '/story/story_edit_content.php',
+            chapters: mappings.map(row => row.chapter),
+            docs,
+            mappings,
+        };
+
+        const plan = StoryEditContent._buildMappingPlan(mappings);
+        const promise = StoryEditContent.runBulkReplace(mockEvent(btn), plan, status, results);
+        await vi.runAllTimersAsync();
+        await promise;
+        await vi.runAllTimersAsync();
+
+        return { btn, status, results, plan };
+    }
+
+    it('blocks execution when duplicate doc mappings exist', async () => {
+        const mappings = makeMappings(2);
+        const docs = makeDocs('StoryName', 1, 2);
+        StoryEditContent._setManualDocSelection(mappings, docs, 0, 'StoryName-1');
+        StoryEditContent._setManualDocSelection(mappings, docs, 1, 'StoryName-1');
+        const validateSpy = vi.spyOn(DocFetchService, 'validatePrivateDocHasContentWithResult');
+
+        const { status } = await runBulkReplaceWithState(mappings, docs);
+
+        expect(status.textContent).toContain('duplicate doc mappings');
+        expect(validateSpy).not.toHaveBeenCalled();
+        expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it('blocks chapter replace POSTs when the source document is empty', async () => {
+        const mappings = makeMappings(1);
+        const docs = makeDocs('StoryName', 1, 1);
+        StoryEditContent._setManualDocSelection(mappings, docs, 0, 'StoryName-1');
+
+        vi.spyOn(DocFetchService, 'validatePrivateDocHasContentWithResult').mockResolvedValue({
+            ok: false,
+            reason: 'Source document is empty.',
+        });
+
+        const { status, results } = await runBulkReplaceWithState(mappings, docs);
+
+        expect(status.textContent).toContain('No chapters were replaced');
+        expect(results.innerHTML).toContain('Source document is empty.');
+        expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it('posts the expected replace body and treats a successful response as success', async () => {
+        const mappings = makeMappings(1);
+        const docs = makeDocs('StoryName', 1, 1);
+        StoryEditContent._setManualDocSelection(mappings, docs, 0, 'StoryName-1');
+
+        vi.spyOn(DocFetchService, 'validatePrivateDocHasContentWithResult').mockResolvedValue({ ok: true });
+        vi.mocked(globalThis.fetch).mockResolvedValue({
+            ok: true,
+            text: async () => '<html><body>Success</body></html>',
+        } as Response);
+
+        const { status } = await runBulkReplaceWithState(mappings, docs);
+
+        expect(globalThis.fetch).toHaveBeenCalledWith('/story/story_edit_content.php', expect.objectContaining({
+            method: 'POST',
+            credentials: 'same-origin',
+            body: 'storytextid=1001&docid=StoryName-1&action=replace',
+        }));
+        expect(status.textContent).toContain('Replaced all 1 chapter');
+    });
+
+    it('renders a failure table for failed replacements', async () => {
+        const mappings = makeMappings(1);
+        const docs = makeDocs('StoryName', 1, 1);
+        StoryEditContent._setManualDocSelection(mappings, docs, 0, 'StoryName-1');
+
+        vi.spyOn(DocFetchService, 'validatePrivateDocHasContentWithResult').mockResolvedValue({ ok: true });
+        vi.mocked(globalThis.fetch).mockResolvedValue({
+            ok: false,
+            status: 500,
+            text: async () => 'Server error',
+        } as Response);
+
+        const { results } = await runBulkReplaceWithState(mappings, docs);
+
+        expect(results.innerHTML).toContain('Failed Replacements');
+        expect(results.innerHTML).toContain('Chapter 1');
+        expect(results.innerHTML).toContain('StoryName001');
+        expect(results.innerHTML).toContain('HTTP 500');
+    });
+
+    it('renders the failure table helper output', () => {
+        const container = document.createElement('div');
+
+        StoryEditContent._renderFailureTable(container, [{
+            chapterLabel: 'Chapter 7',
+            docName: 'StoryName007',
+            reason: 'Replace failed after retry.',
+        }]);
+
+        expect(container.hidden).toBe(false);
+        expect(container.innerHTML).toContain('Failed Replacements');
+        expect(container.innerHTML).toContain('Chapter 7');
+        expect(container.innerHTML).toContain('StoryName007');
+    });
+});

--- a/src/__tests__/StoryEditContent.test.ts
+++ b/src/__tests__/StoryEditContent.test.ts
@@ -4,6 +4,7 @@ import { DocFetchService } from '../services/DocFetchService';
 import { StoryReplaceService } from '../services/StoryReplaceService';
 import { Core } from '../modules/Core';
 import { StoryEditContentDelegate } from '../delegates/StoryEditContentDelegate';
+import { Elements } from '../enums/Elements';
 import type {
     IStoryEditContentChapter,
     IStoryEditContentDoc,
@@ -90,7 +91,7 @@ describe('StoryEditContent parsing', () => {
 
         const chapters = StoryEditContent._parsePublishedChapters(
             document.querySelector('select[name="storytextid"]'),
-            Array.from(document.querySelectorAll('tbody tr')),
+            StoryEditContentDelegate.getElements(Elements.STORY_EDIT_CHAPTER_ROWS),
         );
         const docs = StoryEditContent._parseDocOptions(document.querySelector('select[name="docid"]'));
 

--- a/src/__tests__/StoryEditContent.test.ts
+++ b/src/__tests__/StoryEditContent.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { StoryEditContent } from '../modules/StoryEditContent';
 import { DocFetchService } from '../services/DocFetchService';
+import { StoryReplaceService } from '../services/StoryReplaceService';
 import type {
     IStoryEditContentChapter,
     IStoryEditContentDoc,
@@ -64,15 +65,15 @@ describe('StoryEditContent parsing', () => {
             <form action="/story/story_edit_content.php">
                 <input type="hidden" name="action" value="replace">
                 <select name="storytextid">
-                    <option value="">Select Chapter</option>
+                    <option value="0">Select Chapter</option>
                     <option value="101">Chapter 1 - One</option>
                     <option value="102">Chapter 2 - Two</option>
                     <option value="103">Chapter 3 - Three</option>
                 </select>
                 <select name="docid">
-                    <option value="">Select Doc</option>
-                    <option value="201">StoryName001</option>
-                    <option value="202">StoryName002</option>
+                    <option value="0">Select Doc</option>
+                    <option value="201">1. StoryName001 (3,128)</option>
+                    <option value="202">2. StoryName002 (2,853)</option>
                 </select>
                 <input type="submit" value="Replace">
             </form>
@@ -254,12 +255,13 @@ describe('StoryEditContent bulk replace execution', () => {
         StoryEditContent._setManualDocSelection(mappings, docs, 0, 'StoryName-1');
         StoryEditContent._setManualDocSelection(mappings, docs, 1, 'StoryName-1');
         const validateSpy = vi.spyOn(DocFetchService, 'validatePrivateDocHasContentWithResult');
+        const replaceSpy = vi.spyOn(StoryReplaceService, 'submitReplaceForm');
 
         const { status } = await runBulkReplaceWithState(mappings, docs);
 
         expect(status.textContent).toContain('duplicate doc mappings');
         expect(validateSpy).not.toHaveBeenCalled();
-        expect(globalThis.fetch).not.toHaveBeenCalled();
+        expect(replaceSpy).not.toHaveBeenCalled();
     });
 
     it('blocks chapter replace POSTs when the source document is empty', async () => {
@@ -271,32 +273,26 @@ describe('StoryEditContent bulk replace execution', () => {
             ok: false,
             reason: 'Source document is empty.',
         });
+        const replaceSpy = vi.spyOn(StoryReplaceService, 'submitReplaceForm');
 
         const { status, results } = await runBulkReplaceWithState(mappings, docs);
 
         expect(status.textContent).toContain('No chapters were replaced');
         expect(results.innerHTML).toContain('Source document is empty.');
-        expect(globalThis.fetch).not.toHaveBeenCalled();
+        expect(replaceSpy).not.toHaveBeenCalled();
     });
 
-    it('posts the expected replace body and treats a successful response as success', async () => {
+    it('submits the expected hidden-page replace request and treats success as success', async () => {
         const mappings = makeMappings(1);
         const docs = makeDocs('StoryName', 1, 1);
         StoryEditContent._setManualDocSelection(mappings, docs, 0, 'StoryName-1');
 
         vi.spyOn(DocFetchService, 'validatePrivateDocHasContentWithResult').mockResolvedValue({ ok: true });
-        vi.mocked(globalThis.fetch).mockResolvedValue({
-            ok: true,
-            text: async () => '<html><body>Success</body></html>',
-        } as Response);
+        const replaceSpy = vi.spyOn(StoryReplaceService, 'submitReplaceForm').mockResolvedValue({ ok: true });
 
         const { status } = await runBulkReplaceWithState(mappings, docs);
 
-        expect(globalThis.fetch).toHaveBeenCalledWith('/story/story_edit_content.php', expect.objectContaining({
-            method: 'POST',
-            credentials: 'same-origin',
-            body: 'storytextid=1001&docid=StoryName-1&action=replace',
-        }));
+        expect(replaceSpy).toHaveBeenCalledWith('/story/story_edit_content.php', '1001', 'StoryName-1');
         expect(status.textContent).toContain('Replaced all 1 chapter');
     });
 
@@ -306,11 +302,10 @@ describe('StoryEditContent bulk replace execution', () => {
         StoryEditContent._setManualDocSelection(mappings, docs, 0, 'StoryName-1');
 
         vi.spyOn(DocFetchService, 'validatePrivateDocHasContentWithResult').mockResolvedValue({ ok: true });
-        vi.mocked(globalThis.fetch).mockResolvedValue({
+        vi.spyOn(StoryReplaceService, 'submitReplaceForm').mockResolvedValue({
             ok: false,
-            status: 500,
-            text: async () => 'Server error',
-        } as Response);
+            reason: 'Replace request failed with HTTP 500.',
+        });
 
         const { results } = await runBulkReplaceWithState(mappings, docs);
 
@@ -333,5 +328,85 @@ describe('StoryEditContent bulk replace execution', () => {
         expect(container.innerHTML).toContain('Failed Replacements');
         expect(container.innerHTML).toContain('Chapter 7');
         expect(container.innerHTML).toContain('StoryName007');
+    });
+});
+
+describe('StoryReplaceService hidden page submitter', () => {
+    beforeEach(() => {
+        cleanupDOM();
+        vi.useFakeTimers();
+        vi.restoreAllMocks();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        cleanupDOM();
+    });
+
+    function writeFrameHtml(iframe: HTMLIFrameElement, html: string) {
+        const doc = iframe.contentDocument;
+        if (!doc) throw new Error('Missing iframe document');
+        doc.open();
+        doc.write(html);
+        doc.close();
+    }
+
+    it('loads StoryEditContent in a hidden iframe and submits its native replace form', async () => {
+        const promise = StoryReplaceService.submitReplaceForm('/story/story_edit_content.php?storyid=1', '101', '201');
+        const frame = document.querySelector('iframe') as HTMLIFrameElement;
+
+        expect(frame).not.toBeNull();
+        expect(frame.src).toBe('http://localhost:3000/story/story_edit_content.php?storyid=1');
+
+        writeFrameHtml(frame, `
+            <form id="replacechapter" method="post" action="?storyid=1">
+                <select name="storytextid">
+                    <option value="101">1. Chapter</option>
+                </select>
+                <select name="docid">
+                    <option value="201">StoryName001</option>
+                </select>
+                <input type="hidden" name="action" value="replace">
+            </form>
+        `);
+        const form = frame.contentDocument?.querySelector('form') as HTMLFormElement;
+        const submitSpy = vi.fn(function (this: HTMLFormElement) {
+            expect(this.ownerDocument).toBe(frame.contentDocument);
+            expect((this.elements.namedItem('storytextid') as HTMLSelectElement).value).toBe('101');
+            expect((this.elements.namedItem('docid') as HTMLSelectElement).value).toBe('201');
+            expect((this.elements.namedItem('action') as HTMLInputElement).value).toBe('replace');
+
+            writeFrameHtml(frame, '<div class="panel_success">Success</div>');
+            frame.dispatchEvent(new Event('load'));
+        });
+        Object.defineProperty(form, 'submit', { value: submitSpy, configurable: true });
+        frame.dispatchEvent(new Event('load'));
+
+        await expect(promise).resolves.toEqual({ ok: true });
+        expect(submitSpy).toHaveBeenCalledTimes(1);
+        expect(document.querySelector('iframe')).toBeNull();
+    });
+
+    it('returns a page error from the hidden replace response', async () => {
+        const promise = StoryReplaceService.submitReplaceForm('/story/story_edit_content.php?storyid=1', '101', '201');
+        const frame = document.querySelector('iframe') as HTMLIFrameElement;
+        writeFrameHtml(frame, `
+            <form id="replacechapter">
+                <select name="storytextid"><option value="101">1</option></select>
+                <select name="docid"><option value="201">Doc</option></select>
+                <input name="action" value="replace">
+            </form>
+        `);
+        const form = frame.contentDocument?.querySelector('form') as HTMLFormElement;
+        Object.defineProperty(form, 'submit', {
+            configurable: true,
+            value: vi.fn(() => {
+                writeFrameHtml(frame, '<div class="panel_error">No permission.</div>');
+                frame.dispatchEvent(new Event('load'));
+            }),
+        });
+        frame.dispatchEvent(new Event('load'));
+
+        await expect(promise).resolves.toEqual({ ok: false, reason: 'No permission.' });
     });
 });

--- a/src/__tests__/StoryEditContent.test.ts
+++ b/src/__tests__/StoryEditContent.test.ts
@@ -156,6 +156,27 @@ describe('StoryEditContent mapping state', () => {
         expect(mappings[6].source).toBe('autofill');
     });
 
+    it('autofills unpadded docs across digit-width boundaries', () => {
+        const mappings = makeMappings(44);
+        const docs = Array.from({ length: 44 }, (_value, index) => {
+            const chapterNumber = index + 1;
+            return {
+                docId: `P-${chapterNumber}`,
+                docName: `P${chapterNumber}`,
+            };
+        });
+
+        StoryEditContent._setManualDocSelection(mappings, docs, 43, 'P-44');
+
+        expect(mappings.map(row => row.selectedDocName)).toEqual(
+            Array.from({ length: 44 }, (_value, index) => `P${index + 1}`)
+        );
+        expect(mappings[0].source).toBe('autofill');
+        expect(mappings[8].selectedDocName).toBe('P9');
+        expect(mappings[9].selectedDocName).toBe('P10');
+        expect(mappings[43].source).toBe('manual');
+    });
+
     it('does not autofill rows more than once after they were autofilled', () => {
         const mappings = makeMappings(4);
         const docs = [

--- a/src/__tests__/StoryEditContent.test.ts
+++ b/src/__tests__/StoryEditContent.test.ts
@@ -5,6 +5,7 @@ import { StoryReplaceService } from '../services/StoryReplaceService';
 import { Core } from '../modules/Core';
 import { StoryEditContentDelegate } from '../delegates/StoryEditContentDelegate';
 import { Elements } from '../enums/Elements';
+import { SettingsManager } from '../modules/SettingsManager';
 import type {
     IStoryEditContentChapter,
     IStoryEditContentDoc,
@@ -167,6 +168,27 @@ describe('StoryEditContent mapping state', () => {
         expect(mappings[3].hasBeenAutofilled).toBe(true);
     });
 
+    it('does not autofill when Bulk Replace autofill is disabled', () => {
+        const mappings = makeMappings(4);
+        const docs = makeDocs('StoryName', 1, 4);
+        const getSpy = vi.spyOn(SettingsManager, 'get').mockReturnValue(false);
+
+        try {
+            StoryEditContent._setManualDocSelection(mappings, docs, 1, 'StoryName-2');
+
+            expect(mappings.map(row => row.selectedDocName)).toEqual([
+                '',
+                'StoryName002',
+                '',
+                '',
+            ]);
+            expect(mappings[1].source).toBe('manual');
+            expect(mappings.some(row => row.source === 'autofill')).toBe(false);
+        } finally {
+            getSpy.mockRestore();
+        }
+    });
+
     it('autofilled rows do not cascade new autofill chains', () => {
         const mappings = makeMappings(4);
         const docs = makeDocs('StoryName', 2, 4);
@@ -226,7 +248,7 @@ describe('StoryEditContent injection', () => {
         cleanupDOM();
     });
 
-    it('places Bulk Replace next to the visible Replace/Update Chapter toggle', () => {
+    it('places Bulk Replace as a native-style link next to the visible Replace/Update Chapter toggle', () => {
         document.body.innerHTML = `
             <center>
                 <a href="#">Post New Chapter</a> |
@@ -244,10 +266,14 @@ describe('StoryEditContent injection', () => {
 
         StoryEditContent.injectBulkReplaceButton(document.getElementById('replacechapter') as HTMLFormElement);
 
-        const button = document.getElementById('ffne-story-bulk-replace-btn');
+        const button = document.getElementById('ffne-story-bulk-replace-btn') as HTMLAnchorElement | null;
         const visibleControls = document.querySelector('center');
 
         expect(button).not.toBeNull();
+        expect(button?.tagName).toBe('A');
+        expect(button?.className).toBe('');
+        expect(button?.href).toContain('#');
+        expect(button?.previousSibling?.textContent).toBe(' | ');
         expect(button?.parentElement).toBe(visibleControls);
         expect(document.querySelector('#area_modchapter #ffne-story-bulk-replace-btn')).toBeNull();
     });

--- a/src/delegates/StoryEditContentDelegate.ts
+++ b/src/delegates/StoryEditContentDelegate.ts
@@ -29,7 +29,7 @@ export const StoryEditContentDelegate: IDelegate = {
                 return findReplaceUpdateToggle(doc);
 
             case Elements.STORY_EDIT_ERROR_PANEL:
-                return doc.querySelector<HTMLElement>('.panel_error, .gui_error, .alert-error, .error');
+                return findErrorPanel(doc);
 
             default:
                 return null;
@@ -46,6 +46,13 @@ export const StoryEditContentDelegate: IDelegate = {
         }
     },
 };
+
+function findErrorPanel(doc: Document = document): HTMLElement | null {
+    const candidates = Array.from(doc.querySelectorAll<HTMLElement>(
+        '#replace_err, .panel_error, .gui_error, .alert-error, .error'
+    ));
+    return candidates.find(candidate => !!normalizeText(candidate.textContent || '')) || candidates[0] || null;
+}
 
 function findReplaceForm(doc: Document = document): HTMLFormElement | null {
     const forms = Array.from(doc.forms);

--- a/src/delegates/StoryEditContentDelegate.ts
+++ b/src/delegates/StoryEditContentDelegate.ts
@@ -1,6 +1,7 @@
 import { Elements } from '../enums/Elements';
 import { BaseDelegate } from './BaseDelegate';
 import { IDelegate } from './IDelegate';
+import { STORY_EDIT_CONTENT_CHAPTER_ID_ATTR } from '../interfaces/IStoryEditContent';
 
 export const StoryEditContentDelegate: IDelegate = {
     ...BaseDelegate,
@@ -17,10 +18,12 @@ export const StoryEditContentDelegate: IDelegate = {
                 return findReplaceForm(doc)?.querySelector('select[name="docid"]') || null;
 
             case Elements.STORY_EDIT_REPLACE_ACTION_CONTROL:
-                return findReplaceActionControl(doc);
+                return findNamedReplaceActionControl(doc);
 
-            case Elements.STORY_EDIT_REPLACE_SUBMIT:
-                return findReplaceForm(doc)?.querySelector<HTMLElement>('button[type="submit"], input[type="submit"]') || null;
+            case Elements.STORY_EDIT_REPLACE_SUBMIT: {
+                const form = findReplaceForm(doc);
+                return form ? findReplaceSubmitInForm(form) : null;
+            }
 
             case Elements.STORY_EDIT_REPLACE_TOGGLE:
                 return findReplaceUpdateToggle(doc);
@@ -49,19 +52,26 @@ function findReplaceForm(doc: Document = document): HTMLFormElement | null {
     return forms.find(form => {
         const chapterSelect = form.querySelector('select[name="storytextid"]');
         const docSelect = form.querySelector('select[name="docid"]');
-        const replaceAction = findReplaceActionControlInForm(form);
-        return !!chapterSelect && !!docSelect && !!replaceAction;
+        const replaceAction = findNamedReplaceActionControlInForm(form);
+        const replaceSubmit = findReplaceSubmitInForm(form);
+        return !!chapterSelect && !!docSelect && (!!replaceAction || !!replaceSubmit);
     }) || null;
 }
 
-function findReplaceActionControl(doc: Document = document): HTMLElement | null {
+function findNamedReplaceActionControl(doc: Document = document): HTMLElement | null {
     const form = findReplaceForm(doc);
-    return form ? findReplaceActionControlInForm(form) : null;
+    return form ? findNamedReplaceActionControlInForm(form) : null;
 }
 
-function findReplaceActionControlInForm(form: HTMLFormElement): HTMLElement | null {
+function findNamedReplaceActionControlInForm(form: HTMLFormElement): HTMLElement | null {
     return form.querySelector<HTMLElement>(
-        'input[name="action"][value="replace"], button[name="action"][value="replace"], input[type="submit"][value*="Replace"], button[type="submit"][value="replace"]'
+        'input[name="action"][value="replace"], button[name="action"][value="replace"]'
+    );
+}
+
+function findReplaceSubmitInForm(form: HTMLFormElement): HTMLElement | null {
+    return form.querySelector<HTMLElement>(
+        'button[type="submit"], input[type="submit"][value*="Replace"], button[type="submit"][value="replace"]'
     );
 }
 
@@ -77,7 +87,11 @@ function findLikelyChapterRows(doc: Document = document): HTMLElement[] {
 
     return explicitRows.filter(row => {
         const text = normalizeText(row.textContent || '');
-        return !!extractStoryTextId(row) || /published|draft|chapter/i.test(text);
+        const storyTextId = extractStoryTextId(row);
+        if (storyTextId) {
+            row.setAttribute(STORY_EDIT_CONTENT_CHAPTER_ID_ATTR, storyTextId);
+        }
+        return !!storyTextId || /published|draft|chapter/i.test(text);
     });
 }
 

--- a/src/delegates/StoryEditContentDelegate.ts
+++ b/src/delegates/StoryEditContentDelegate.ts
@@ -16,6 +16,18 @@ export const StoryEditContentDelegate: IDelegate = {
             case Elements.STORY_EDIT_DOC_SELECT:
                 return findReplaceForm(doc)?.querySelector('select[name="docid"]') || null;
 
+            case Elements.STORY_EDIT_REPLACE_ACTION_CONTROL:
+                return findReplaceActionControl(doc);
+
+            case Elements.STORY_EDIT_REPLACE_SUBMIT:
+                return findReplaceForm(doc)?.querySelector<HTMLElement>('button[type="submit"], input[type="submit"]') || null;
+
+            case Elements.STORY_EDIT_REPLACE_TOGGLE:
+                return findReplaceUpdateToggle(doc);
+
+            case Elements.STORY_EDIT_ERROR_PANEL:
+                return doc.querySelector<HTMLElement>('.panel_error, .gui_error, .alert-error, .error');
+
             default:
                 return null;
         }
@@ -37,11 +49,25 @@ function findReplaceForm(doc: Document = document): HTMLFormElement | null {
     return forms.find(form => {
         const chapterSelect = form.querySelector('select[name="storytextid"]');
         const docSelect = form.querySelector('select[name="docid"]');
-        const replaceAction = form.querySelector(
-            'input[name="action"][value="replace"], button[name="action"][value="replace"], input[type="submit"][value*="Replace"], button[type="submit"][value="replace"]'
-        );
+        const replaceAction = findReplaceActionControlInForm(form);
         return !!chapterSelect && !!docSelect && !!replaceAction;
     }) || null;
+}
+
+function findReplaceActionControl(doc: Document = document): HTMLElement | null {
+    const form = findReplaceForm(doc);
+    return form ? findReplaceActionControlInForm(form) : null;
+}
+
+function findReplaceActionControlInForm(form: HTMLFormElement): HTMLElement | null {
+    return form.querySelector<HTMLElement>(
+        'input[name="action"][value="replace"], button[name="action"][value="replace"], input[type="submit"][value*="Replace"], button[type="submit"][value="replace"]'
+    );
+}
+
+function findReplaceUpdateToggle(doc: Document = document): HTMLAnchorElement | null {
+    return Array.from(doc.querySelectorAll<HTMLAnchorElement>('a[href="#"], a'))
+        .find(anchor => /replace\s*\/\s*update\s+chapter/i.test(normalizeText(anchor.textContent || ''))) || null;
 }
 
 function findLikelyChapterRows(doc: Document = document): HTMLElement[] {

--- a/src/delegates/StoryEditContentDelegate.ts
+++ b/src/delegates/StoryEditContentDelegate.ts
@@ -1,0 +1,76 @@
+import { Elements } from '../enums/Elements';
+import { BaseDelegate } from './BaseDelegate';
+import { IDelegate } from './IDelegate';
+
+export const StoryEditContentDelegate: IDelegate = {
+    ...BaseDelegate,
+
+    getElement(key: Elements, doc: Document = document): HTMLElement | null {
+        switch (key) {
+            case Elements.STORY_EDIT_REPLACE_FORM:
+                return findReplaceForm(doc);
+
+            case Elements.STORY_EDIT_CHAPTER_SELECT:
+                return findReplaceForm(doc)?.querySelector('select[name="storytextid"]') || null;
+
+            case Elements.STORY_EDIT_DOC_SELECT:
+                return findReplaceForm(doc)?.querySelector('select[name="docid"]') || null;
+
+            default:
+                return null;
+        }
+    },
+
+    getElements(key: Elements, doc: Document = document): HTMLElement[] {
+        switch (key) {
+            case Elements.STORY_EDIT_CHAPTER_ROWS:
+                return findLikelyChapterRows(doc);
+
+            default:
+                return [];
+        }
+    },
+};
+
+function findReplaceForm(doc: Document = document): HTMLFormElement | null {
+    const forms = Array.from(doc.forms);
+    return forms.find(form => {
+        const chapterSelect = form.querySelector('select[name="storytextid"]');
+        const docSelect = form.querySelector('select[name="docid"]');
+        const replaceAction = form.querySelector(
+            'input[name="action"][value="replace"], button[name="action"][value="replace"], input[type="submit"][value*="Replace"], button[type="submit"][value="replace"]'
+        );
+        return !!chapterSelect && !!docSelect && !!replaceAction;
+    }) || null;
+}
+
+function findLikelyChapterRows(doc: Document = document): HTMLElement[] {
+    const explicitRows = Array.from(doc.querySelectorAll<HTMLElement>(
+        'tr[data-storytextid], tr[data-story-text-id], tr[data-storytext-id], table tbody tr'
+    ));
+
+    return explicitRows.filter(row => {
+        const text = normalizeText(row.textContent || '');
+        return !!extractStoryTextId(row) || /published|draft|chapter/i.test(text);
+    });
+}
+
+function extractStoryTextId(row: HTMLElement): string {
+    const dataId = row.getAttribute('data-storytextid')
+        || row.getAttribute('data-story-text-id')
+        || row.getAttribute('data-storytext-id');
+    if (dataId) return dataId;
+
+    const candidates = Array.from(row.querySelectorAll<HTMLElement>('a[href], input[value], button[value], select option[value]'));
+    for (const candidate of candidates) {
+        const value = candidate instanceof HTMLAnchorElement ? candidate.href : candidate.getAttribute('value') || '';
+        const match = value.match(/storytextid=(\d+)/i) || value.match(/^(\d+)$/);
+        if (match) return match[1];
+    }
+
+    return '';
+}
+
+function normalizeText(value: string): string {
+    return value.replace(/\s+/g, ' ').trim();
+}

--- a/src/enums/Elements.ts
+++ b/src/enums/Elements.ts
@@ -105,4 +105,20 @@ export enum Elements {
 
     /** The panel that appears after saving (whether successfully or not) */
     SUCCESS_PANEL = 'SUCCESS_PANEL',
+
+    // =============================
+    // STORY EDIT CONTENT (/story/story_edit_content.php)
+    // =============================
+
+    /** The existing FFN replace form used for chapter replacement. */
+    STORY_EDIT_REPLACE_FORM = 'STORY_EDIT_REPLACE_FORM',
+
+    /** The chapter selector used by FFN's native replace control. */
+    STORY_EDIT_CHAPTER_SELECT = 'STORY_EDIT_CHAPTER_SELECT',
+
+    /** The document selector used by FFN's native replace control. */
+    STORY_EDIT_DOC_SELECT = 'STORY_EDIT_DOC_SELECT',
+
+    /** The chapter listing rows shown on the story edit content page. */
+    STORY_EDIT_CHAPTER_ROWS = 'STORY_EDIT_CHAPTER_ROWS',
 }

--- a/src/enums/Elements.ts
+++ b/src/enums/Elements.ts
@@ -119,6 +119,18 @@ export enum Elements {
     /** The document selector used by FFN's native replace control. */
     STORY_EDIT_DOC_SELECT = 'STORY_EDIT_DOC_SELECT',
 
+    /** The hidden/action field that marks FFN's native replace action. */
+    STORY_EDIT_REPLACE_ACTION_CONTROL = 'STORY_EDIT_REPLACE_ACTION_CONTROL',
+
+    /** The visible submit control in FFN's native replace form. */
+    STORY_EDIT_REPLACE_SUBMIT = 'STORY_EDIT_REPLACE_SUBMIT',
+
+    /** The visible "Replace/Update Chapter" toggle link. */
+    STORY_EDIT_REPLACE_TOGGLE = 'STORY_EDIT_REPLACE_TOGGLE',
+
     /** The chapter listing rows shown on the story edit content page. */
     STORY_EDIT_CHAPTER_ROWS = 'STORY_EDIT_CHAPTER_ROWS',
+
+    /** Error panel returned by StoryEditContent actions. */
+    STORY_EDIT_ERROR_PANEL = 'STORY_EDIT_ERROR_PANEL',
 }

--- a/src/interfaces/IBulkOperationConfig.ts
+++ b/src/interfaces/IBulkOperationConfig.ts
@@ -5,13 +5,21 @@ export interface IBulkItem {
     title: string;
     row: HTMLTableRowElement;
 }
-export interface IBulkOperationConfig {
+
+export interface IBulkOperationResult<TItem = IBulkItem> {
+    successCount: number;
+    totalCount: number;
+    retriedItems: TItem[];
+}
+
+export interface IBulkOperationConfig<TItem = IBulkItem> {
     verb: string;
-    filterRows?: (items: IBulkItem[]) => IBulkItem[];
-    processItem: (item: IBulkItem) => Promise<boolean>;
-    onItemStart?: (item: IBulkItem, pass: 1 | 2, index: number, total: number) => void;
-    onItemSuccess?: (item: IBulkItem, pass: 1 | 2) => void;
-    onPermanentFailure?: (item: IBulkItem) => void;
+    getItems: () => TItem[];
+    filterRows?: (items: TItem[]) => TItem[];
+    processItem: (item: TItem) => Promise<boolean>;
+    onItemStart?: (item: TItem, pass: 1 | 2, index: number, total: number) => void;
+    onItemSuccess?: (item: TItem, pass: 1 | 2) => void;
+    onPermanentFailure?: (item: TItem) => void;
     preBatch?: (totalCount: number) => void;
-    onFinalize?: (result: { successCount: number; totalCount: number; retriedItems: IBulkItem[]; }) => void | Promise<void>;
+    onFinalize?: (result: IBulkOperationResult<TItem>) => void | Promise<void>;
 }

--- a/src/interfaces/IStoryEditContent.ts
+++ b/src/interfaces/IStoryEditContent.ts
@@ -1,3 +1,5 @@
+export const STORY_EDIT_CONTENT_CHAPTER_ID_ATTR = 'data-ffne-story-text-id';
+
 export interface IStoryEditContentChapter {
     storyTextId: string;
     chapterNumber: number;

--- a/src/interfaces/IStoryEditContent.ts
+++ b/src/interfaces/IStoryEditContent.ts
@@ -1,0 +1,39 @@
+export interface IStoryEditContentChapter {
+    storyTextId: string;
+    chapterNumber: number;
+    chapterLabel: string;
+    published: boolean;
+    row: HTMLTableRowElement | null;
+}
+
+export interface IStoryEditContentDoc {
+    docId: string;
+    docName: string;
+}
+
+export type StoryEditContentMappingSource = 'unmapped' | 'manual' | 'autofill';
+export type StoryEditContentMappingStatus = 'unmapped' | 'mapped' | 'duplicate' | 'running' | 'success' | 'failed' | 'skipped';
+
+export interface IStoryEditContentMappingRow {
+    chapter: IStoryEditContentChapter;
+    selectedDocId: string;
+    selectedDocName: string;
+    source: StoryEditContentMappingSource;
+    hasBeenAutofilled: boolean;
+    status: StoryEditContentMappingStatus;
+    modalRow: HTMLTableRowElement | null;
+}
+
+export interface IStoryEditContentPlan {
+    rows: IStoryEditContentMappingRow[];
+    mappedCount: number;
+    skippedCount: number;
+    duplicateDocIds: string[];
+    hasBlockingErrors: boolean;
+}
+
+export interface IStoryEditContentFailure {
+    chapterLabel: string;
+    docName: string;
+    reason: string;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -84,7 +84,11 @@ const bootstrap = () => {
          */
         safeInit('DocEditor', () => DocEditor.init());
     }
-    else if (path === '/story/story_edit_content.php') {
+    else if (path.includes('/story/story_edit_content.php')) {
+        /**
+         * Route: Story Edit Content
+         * Features: Bulk Replace
+         */
         safeInit('StoryEditContent', () => StoryEditContent.init());
     }
     else if (path.startsWith("/s/")) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { DocEditor } from './modules/DocEditor';
 import { StoryReader } from './modules/StoryReader';
 import { StoryDownloader } from './modules/StoryDownloader';
 import { LayoutManager } from './modules/LayoutManager';
+import { StoryEditContent } from './modules/StoryEditContent';
 
 /**
  * The Entry Point / Router.
@@ -82,6 +83,9 @@ const bootstrap = () => {
          * Features: Single Document Download button in Toolbar
          */
         safeInit('DocEditor', () => DocEditor.init());
+    }
+    else if (path === '/story/story_edit_content.php') {
+        safeInit('StoryEditContent', () => StoryEditContent.init());
     }
     else if (path.startsWith("/s/")) {
         /**

--- a/src/modules/Core.ts
+++ b/src/modules/Core.ts
@@ -6,6 +6,7 @@ import { IDelegate } from '../delegates/IDelegate';
 import { DocManagerDelegate } from '../delegates/DocManagerDelegate';
 import { DocEditorDelegate } from '../delegates/DocEditorDelegate';
 import { GlobalDelegate } from '../delegates/GlobalDelegate';
+import { StoryEditContentDelegate } from '../delegates/StoryEditContentDelegate';
 import { FFNLogger } from './FFNLogger';
 
 /**
@@ -82,6 +83,10 @@ export const Core = {
             this.activeDelegate = StoryDelegate;
             log('Strategy set to StoryDelegate');
         }
+        else if (pagePath === '/story/story_edit_content.php') {
+            this.activeDelegate = StoryEditContentDelegate;
+            log('Strategy set to StoryEditContentDelegate');
+        }
         else if (pagePath === "/docs/docs.php") {
             this.activeDelegate = DocManagerDelegate;
             log('Strategy set to DocManagerDelegate');
@@ -150,4 +155,3 @@ export const Core = {
     },
 
 };
-

--- a/src/modules/DocManager.ts
+++ b/src/modules/DocManager.ts
@@ -13,6 +13,7 @@ import { IBulkOperationConfig, IBulkItem } from '../interfaces/IBulkOperationCon
 import { applyExportTransforms } from '../utils/exportTransform';
 import { writeToClipboard } from '../utils/clipboard';
 import { SimpleMarkdownParser } from './SimpleMarkdownParser';
+import { runBulkOperation } from '../utils/runBulkOperation';
 
 const ADVANCED_DRAWER_ID = 'ffne-docmanager-advanced-drawer';
 const ADVANCED_MODAL_ID = 'ffne-docmanager-advanced-modal';
@@ -288,94 +289,14 @@ function _readFileAsText(file: File): Promise<string> {
  * Handles: row extraction, progress UI, two-pass retry with delays, error handling, button reset.
  * Operation-specific logic injected via callbacks.
  */
-async function _runBulkOperation(e: MouseEvent, config: IBulkOperationConfig): Promise<void> {
-    const log = Core.getLogger(DocManager.MODULE_NAME, '_runBulkOperation');
-    const { verb, processItem, onItemStart, onItemSuccess, onPermanentFailure, preBatch, onFinalize } = config;
-
-    log(`${verb} initiated.`);
-    const btn = e.currentTarget as HTMLButtonElement;
-
-    if (!Core.getElement(Elements.DOC_TABLE)) {
-        log("Table not found.");
-        return;
-    }
-
-    let items = _collectBulkItems();
-
-    if (config.filterRows) {
-        items = config.filterRows(items);
-    }
-
-    if (items.length === 0) {
-        log("No documents to process.");
-        return;
-    }
-
-    if (preBatch) preBatch(items.length);
-
-    const originalText = btn.innerText;
-    btn.disabled = true;
-    btn.style.cursor = "wait";
-    btn.style.opacity = "1";
-
-    let successCount = 0;
-    const retriedItems: IBulkItem[] = [];
-
-    try {
-        // PASS 1: Initial attempt
-        for (let i = 0; i < items.length; i++) {
-            const item = items[i];
-            btn.innerText = `${i + 1}/${items.length}`;
-            if (onItemStart) onItemStart(item, 1, i + 1, items.length);
-
-            await new Promise(r => setTimeout(r, SettingsManager.get('bulkExportDelayMs')));
-
-            if (await processItem(item)) {
-                successCount++;
-                if (onItemSuccess) onItemSuccess(item, 1);
-            } else {
-                retriedItems.push(item);
-            }
-        }
-
-        // PASS 2: Retry failures after cooldown
-        if (retriedItems.length > 0) {
-            log(`Pass 1 done. ${retriedItems.length} items failed. Cooling...`);
-            btn.innerText = "Cooling...";
-            await new Promise(r => setTimeout(r, SettingsManager.get('bulkCooldownMs')));
-
-            for (let i = 0; i < retriedItems.length; i++) {
-                const item = retriedItems[i];
-                btn.innerText = `Retry ${i + 1}/${retriedItems.length}`;
-                if (onItemStart) onItemStart(item, 2, i + 1, retriedItems.length);
-
-                await new Promise(r => setTimeout(r, SettingsManager.get('bulkRetryDelayMs')));
-
-                if (await processItem(item)) {
-                    successCount++;
-                    if (onItemSuccess) onItemSuccess(item, 2);
-                } else {
-                    log(`Pass 2 Permanent Failure for ${item.title}`);
-                    if (onPermanentFailure) onPermanentFailure(item);
-                }
-            }
-        }
-
-        // Finalization
-        if (onFinalize) {
-            await onFinalize({ successCount, totalCount: items.length, retriedItems });
-        }
-    } catch (error) {
-        log(`Error during bulk ${verb}.`, error);
-        btn.innerText = "Error";
-    } finally {
-        setTimeout(() => {
-            btn.innerText = originalText;
-            btn.disabled = false;
-            btn.style.cursor = "pointer";
-            btn.style.opacity = "0.6";
-        }, 3000);
-    }
+async function _runBulkOperation(
+    e: MouseEvent,
+    config: Omit<IBulkOperationConfig<IBulkItem>, 'getItems'>,
+): Promise<void> {
+    return runBulkOperation(e, {
+        ...config,
+        getItems: _collectBulkItems,
+    });
 }
 
 /**

--- a/src/modules/SettingsManager.ts
+++ b/src/modules/SettingsManager.ts
@@ -64,6 +64,12 @@ export interface FFNSettings {
     appendSeparator: boolean;
 
     /**
+     * When true, Bulk Replace auto-maps nearby numbered docs after a manual
+     * source-doc selection.
+     */
+    bulkReplaceAutofill: boolean;
+
+    /**
      * Number of pixels to scroll per W/S/↑/↓ keypress on story reading pages.
      */
     scrollStep: number;
@@ -125,6 +131,7 @@ const DEFAULTS: FFNSettings = {
     pasteForceIntercept: false,
     ao3HtmlCompatibility: true,
     appendSeparator: false,
+    bulkReplaceAutofill: false,
     scrollStep: 300,
     fetchMaxRetries: 3,
     fetchRetryBaseMs: 2000,
@@ -306,6 +313,7 @@ function _loadAll(): void {
     _loadBool('pasteForceIntercept');
     _loadBool('ao3HtmlCompatibility');
     _loadBool('appendSeparator');
+    _loadBool('bulkReplaceAutofill');
     _loadPositiveNumber('scrollStep');
     _loadPositiveNumber('fetchMaxRetries');
     _loadPositiveNumber('fetchRetryBaseMs');

--- a/src/modules/SettingsManager.ts
+++ b/src/modules/SettingsManager.ts
@@ -131,7 +131,7 @@ const DEFAULTS: FFNSettings = {
     pasteForceIntercept: false,
     ao3HtmlCompatibility: true,
     appendSeparator: false,
-    bulkReplaceAutofill: false,
+    bulkReplaceAutofill: true,
     scrollStep: 300,
     fetchMaxRetries: 3,
     fetchRetryBaseMs: 2000,

--- a/src/modules/SettingsPage.ts
+++ b/src/modules/SettingsPage.ts
@@ -22,6 +22,7 @@ const BOOL_KEYS: (keyof FFNSettings)[] = [
     'pasteForceIntercept',
     'ao3HtmlCompatibility',
     'appendSeparator',
+    'bulkReplaceAutofill',
 ];
 
 /**
@@ -217,6 +218,15 @@ function _buildModalHTML(): string {
                         'Pixels scrolled per keypress when using W / S / ↑ / ↓ on story pages.',
                         s.get('scrollStep'),
                         { min: 50, max: 1000, step: 50, unit: 'px' }
+                    ),
+                ])}
+
+                ${_buildSection('Author Tools', [
+                    _buildToggleRow(
+                        'bulkReplaceAutofill',
+                        'Autofill in Bulk Replace',
+                        'When selecting one numbered source document in Bulk Replace, automatically maps matching numbered docs to nearby chapters.',
+                        s.get('bulkReplaceAutofill')
                     ),
                 ])}
 

--- a/src/modules/StoryEditContent.ts
+++ b/src/modules/StoryEditContent.ts
@@ -351,10 +351,15 @@ export const StoryEditContent = {
         button.textContent = 'Bulk Replace';
         button.addEventListener('click', () => this.openBulkReplaceModal());
 
-        const replaceControl = form.querySelector<HTMLElement>(
-            'button[type="submit"], input[type="submit"]'
-        );
-        if (replaceControl?.parentElement) {
+        const replaceToggle = Core.getElement(Elements.STORY_EDIT_REPLACE_TOGGLE) as HTMLAnchorElement | null;
+        if (replaceToggle?.parentElement) {
+            const spacer = document.createTextNode(' ');
+            replaceToggle.after(spacer, button);
+            return;
+        }
+
+        const replaceControl = Core.getElement(Elements.STORY_EDIT_REPLACE_SUBMIT) as HTMLElement | null;
+        if (replaceControl) {
             replaceControl.insertAdjacentElement('afterend', button);
         } else {
             form.appendChild(button);

--- a/src/modules/StoryEditContent.ts
+++ b/src/modules/StoryEditContent.ts
@@ -433,7 +433,6 @@ export const StoryEditContent = {
             if (!confirmed) return;
 
             await this.runBulkReplace(e as MouseEvent, plan, status, results);
-            this._refreshPlan(summary, startButton);
         });
 
         overlay.querySelector<HTMLButtonElement>('.ffne-story-bulk-close')

--- a/src/modules/StoryEditContent.ts
+++ b/src/modules/StoryEditContent.ts
@@ -5,6 +5,7 @@ import {
     IStoryEditContentFailure,
     IStoryEditContentMappingRow,
     IStoryEditContentPlan,
+    STORY_EDIT_CONTENT_CHAPTER_ID_ATTR,
 } from '../interfaces/IStoryEditContent';
 import { IBulkOperationConfig } from '../interfaces/IBulkOperationConfig';
 import { Core } from './Core';
@@ -60,21 +61,7 @@ function _extractChapterNumber(label: string, fallbackNumber: number): number {
 }
 
 function _extractStoryTextId(row: HTMLElement): string {
-    const direct = row.getAttribute('data-storytextid')
-        || row.getAttribute('data-story-text-id')
-        || row.getAttribute('data-storytext-id');
-    if (direct) return direct;
-
-    const selectors = ['a[href*="storytextid="]', 'input[name="storytextid"]', 'input[value]', 'button[value]'];
-    for (const selector of selectors) {
-        const element = row.querySelector<HTMLElement>(selector);
-        if (!element) continue;
-        const value = element instanceof HTMLAnchorElement ? element.href : element.getAttribute('value') || '';
-        const match = value.match(/storytextid=(\d+)/i) || value.match(/^(\d+)$/);
-        if (match) return match[1];
-    }
-
-    return '';
+    return row.getAttribute(STORY_EDIT_CONTENT_CHAPTER_ID_ATTR) || '';
 }
 
 function _parsePublishedChapters(

--- a/src/modules/StoryEditContent.ts
+++ b/src/modules/StoryEditContent.ts
@@ -173,10 +173,39 @@ function _parseSemanticDocName(docName: string): ParsedSemanticDocName | null {
 }
 
 function _buildDocMaps(docs: IStoryEditContentDoc[]) {
+    const bySemanticNumber = new Map<string, IStoryEditContentDoc | null>();
+
+    docs.forEach(doc => {
+        const parsed = _parseSemanticDocName(doc.docName);
+        if (!parsed) return;
+
+        const key = `${parsed.prefix}\u0000${parsed.number}`;
+        if (bySemanticNumber.has(key)) {
+            bySemanticNumber.set(key, null);
+        } else {
+            bySemanticNumber.set(key, doc);
+        }
+    });
+
     return {
         byId: new Map(docs.map(doc => [doc.docId, doc])),
         byName: new Map(docs.map(doc => [doc.docName, doc])),
+        bySemanticNumber,
     };
+}
+
+function _getSemanticDocMatch(
+    byName: Map<string, IStoryEditContentDoc>,
+    bySemanticNumber: Map<string, IStoryEditContentDoc | null>,
+    prefix: string,
+    candidateNumber: number,
+    padding: number,
+): IStoryEditContentDoc | null {
+    const paddedName = `${prefix}${String(candidateNumber).padStart(padding, '0')}`;
+    const exactMatch = byName.get(paddedName);
+    if (exactMatch) return exactMatch;
+
+    return bySemanticNumber.get(`${prefix}\u0000${candidateNumber}`) || null;
 }
 
 function _applySemanticAutofill(
@@ -189,7 +218,7 @@ function _applySemanticAutofill(
     const anchor = mappings[anchorIndex];
     if (!anchor || !selectedDocId) return mappings;
 
-    const { byId, byName } = _buildDocMaps(docs);
+    const { byId, byName, bySemanticNumber } = _buildDocMaps(docs);
     const anchorDoc = byId.get(selectedDocId);
     const parsed = anchorDoc ? _parseSemanticDocName(anchorDoc.docName) : null;
     if (!anchorDoc || !parsed) {
@@ -208,8 +237,13 @@ function _applySemanticAutofill(
         const candidateNumber = parsed.number + offset;
         if (!Number.isFinite(candidateNumber) || candidateNumber <= 0) continue;
 
-        const candidateName = `${parsed.prefix}${String(candidateNumber).padStart(parsed.padding, '0')}`;
-        const candidateDoc = byName.get(candidateName);
+        const candidateDoc = _getSemanticDocMatch(
+            byName,
+            bySemanticNumber,
+            parsed.prefix,
+            candidateNumber,
+            parsed.padding,
+        );
         if (!candidateDoc) continue;
 
         row.selectedDocId = candidateDoc.docId;

--- a/src/modules/StoryEditContent.ts
+++ b/src/modules/StoryEditContent.ts
@@ -1,0 +1,794 @@
+import { Elements } from '../enums/Elements';
+import {
+    IStoryEditContentChapter,
+    IStoryEditContentDoc,
+    IStoryEditContentFailure,
+    IStoryEditContentMappingRow,
+    IStoryEditContentPlan,
+} from '../interfaces/IStoryEditContent';
+import { IBulkOperationConfig } from '../interfaces/IBulkOperationConfig';
+import { Core } from './Core';
+import { DocFetchService } from '../services/DocFetchService';
+import { StoryReplaceService } from '../services/StoryReplaceService';
+import { runBulkOperation } from '../utils/runBulkOperation';
+
+const BULK_REPLACE_BUTTON_ID = 'ffne-story-bulk-replace-btn';
+const BULK_REPLACE_MODAL_ID = 'ffne-story-bulk-replace-modal';
+const BULK_REPLACE_STYLE_ID = 'ffne-story-bulk-replace-style';
+
+interface StoryEditContentState {
+    actionUrl: string;
+    chapters: IStoryEditContentChapter[];
+    docs: IStoryEditContentDoc[];
+    mappings: IStoryEditContentMappingRow[];
+}
+
+interface ParsedSemanticDocName {
+    prefix: string;
+    number: number;
+    padding: number;
+}
+
+function _normalizeText(value: string): string {
+    return value.replace(/\s+/g, ' ').trim();
+}
+
+function _escapeHtml(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function _extractChapterNumber(label: string, fallbackNumber: number): number {
+    const normalized = _normalizeText(label);
+    const chapterMatch = normalized.match(/(?:chapter|ch\.?|#)\s*(\d+)/i) || normalized.match(/^(\d+)\b/);
+    if (chapterMatch) {
+        const parsed = Number.parseInt(chapterMatch[1], 10);
+        if (Number.isFinite(parsed) && parsed > 0) return parsed;
+    }
+    return fallbackNumber;
+}
+
+function _extractStoryTextId(row: HTMLElement): string {
+    const direct = row.getAttribute('data-storytextid')
+        || row.getAttribute('data-story-text-id')
+        || row.getAttribute('data-storytext-id');
+    if (direct) return direct;
+
+    const selectors = ['a[href*="storytextid="]', 'input[name="storytextid"]', 'input[value]', 'button[value]'];
+    for (const selector of selectors) {
+        const element = row.querySelector<HTMLElement>(selector);
+        if (!element) continue;
+        const value = element instanceof HTMLAnchorElement ? element.href : element.getAttribute('value') || '';
+        const match = value.match(/storytextid=(\d+)/i) || value.match(/^(\d+)$/);
+        if (match) return match[1];
+    }
+
+    return '';
+}
+
+function _parsePublishedChapters(
+    chapterSelect: HTMLSelectElement | null,
+    chapterRows: HTMLElement[] = [],
+): IStoryEditContentChapter[] {
+    if (!chapterSelect) return [];
+
+    const options = Array.from(chapterSelect.options)
+        .map((option, index) => ({ option, index }))
+        .filter(({ option }) => !!option.value.trim())
+        .map(({ option, index }) => ({
+            storyTextId: option.value.trim(),
+            chapterNumber: _extractChapterNumber(option.textContent || option.label || '', index + 1),
+            chapterLabel: _normalizeText(option.textContent || option.label || `Chapter ${index + 1}`),
+        }));
+
+    const publishedById = new Set<string>();
+    const publishedIndices: number[] = [];
+    let sawStatusMarkers = false;
+
+    chapterRows.forEach((row, index) => {
+        const text = _normalizeText(row.textContent || '');
+        if (!text) return;
+
+        const isDraft = /unpublished|draft|not published/i.test(text);
+        const isPublished = /published/i.test(text) && !isDraft;
+        if (/published|draft|unpublished/i.test(text)) {
+            sawStatusMarkers = true;
+        }
+        if (!isPublished) return;
+
+        const storyTextId = _extractStoryTextId(row);
+        if (storyTextId) {
+            publishedById.add(storyTextId);
+        } else {
+            publishedIndices.push(index);
+        }
+    });
+
+    if (publishedById.size > 0) {
+        const rowById = new Map(chapterRows.map(row => [_extractStoryTextId(row), row as HTMLTableRowElement]));
+        return options
+            .filter(option => publishedById.has(option.storyTextId))
+            .map(option => ({
+                ...option,
+                published: true,
+                row: rowById.get(option.storyTextId) || null,
+            }));
+    }
+
+    if (sawStatusMarkers && publishedIndices.length > 0) {
+        return publishedIndices
+            .map(index => options[index])
+            .filter((option): option is typeof options[number] => !!option)
+            .map(option => ({
+                ...option,
+                published: true,
+                row: chapterRows[options.indexOf(option)] as HTMLTableRowElement | null,
+            }));
+    }
+
+    return options.map(option => ({
+        ...option,
+        published: true,
+        row: null,
+    }));
+}
+
+function _parseDocOptions(docSelect: HTMLSelectElement | null): IStoryEditContentDoc[] {
+    if (!docSelect) return [];
+
+    const seen = new Set<string>();
+    const docs: IStoryEditContentDoc[] = [];
+    for (const option of Array.from(docSelect.options)) {
+        const docId = option.value.trim();
+        const docName = _normalizeText(option.textContent || option.label || '');
+        if (!docId || !docName || seen.has(docId)) continue;
+        seen.add(docId);
+        docs.push({ docId, docName });
+    }
+    return docs;
+}
+
+function _createMappingRows(chapters: IStoryEditContentChapter[]): IStoryEditContentMappingRow[] {
+    return chapters.map(chapter => ({
+        chapter,
+        selectedDocId: '',
+        selectedDocName: '',
+        source: 'unmapped',
+        hasBeenAutofilled: false,
+        status: 'unmapped',
+        modalRow: null,
+    }));
+}
+
+function _parseSemanticDocName(docName: string): ParsedSemanticDocName | null {
+    const match = docName.match(/^(.*?)(\d+)$/);
+    if (!match) return null;
+
+    return {
+        prefix: match[1],
+        number: Number.parseInt(match[2], 10),
+        padding: match[2].length,
+    };
+}
+
+function _buildDocMaps(docs: IStoryEditContentDoc[]) {
+    return {
+        byId: new Map(docs.map(doc => [doc.docId, doc])),
+        byName: new Map(docs.map(doc => [doc.docName, doc])),
+    };
+}
+
+function _applySemanticAutofill(
+    mappings: IStoryEditContentMappingRow[],
+    docs: IStoryEditContentDoc[],
+    anchorIndex: number,
+    selectedDocId: string,
+): IStoryEditContentMappingRow[] {
+    const anchor = mappings[anchorIndex];
+    if (!anchor || !selectedDocId) return mappings;
+
+    const { byId, byName } = _buildDocMaps(docs);
+    const anchorDoc = byId.get(selectedDocId);
+    const parsed = anchorDoc ? _parseSemanticDocName(anchorDoc.docName) : null;
+    if (!anchorDoc || !parsed) return mappings;
+
+    for (let index = 0; index < mappings.length; index++) {
+        if (index === anchorIndex) continue;
+
+        const row = mappings[index];
+        if (row.source === 'manual' || row.hasBeenAutofilled) continue;
+
+        const offset = row.chapter.chapterNumber - anchor.chapter.chapterNumber;
+        const candidateNumber = parsed.number + offset;
+        if (!Number.isFinite(candidateNumber) || candidateNumber <= 0) continue;
+
+        const candidateName = `${parsed.prefix}${String(candidateNumber).padStart(parsed.padding, '0')}`;
+        const candidateDoc = byName.get(candidateName);
+        if (!candidateDoc) continue;
+
+        row.selectedDocId = candidateDoc.docId;
+        row.selectedDocName = candidateDoc.docName;
+        row.source = 'autofill';
+        row.hasBeenAutofilled = true;
+        row.status = 'mapped';
+    }
+
+    return mappings;
+}
+
+function _setManualDocSelection(
+    mappings: IStoryEditContentMappingRow[],
+    docs: IStoryEditContentDoc[],
+    rowIndex: number,
+    docId: string,
+): IStoryEditContentMappingRow[] {
+    const row = mappings[rowIndex];
+    if (!row) return mappings;
+
+    const { byId } = _buildDocMaps(docs);
+    const doc = byId.get(docId);
+    row.selectedDocId = doc?.docId || '';
+    row.selectedDocName = doc?.docName || '';
+    row.source = doc ? 'manual' : 'unmapped';
+    row.status = doc ? 'mapped' : 'unmapped';
+
+    if (doc) {
+        _applySemanticAutofill(mappings, docs, rowIndex, doc.docId);
+    }
+
+    return mappings;
+}
+
+function _buildMappingPlan(mappings: IStoryEditContentMappingRow[]): IStoryEditContentPlan {
+    const counts = new Map<string, number>();
+    let mappedCount = 0;
+    let skippedCount = 0;
+
+    mappings.forEach(row => {
+        if (!row.selectedDocId) {
+            skippedCount++;
+            row.status = 'skipped';
+            return;
+        }
+
+        mappedCount++;
+        counts.set(row.selectedDocId, (counts.get(row.selectedDocId) || 0) + 1);
+        row.status = 'mapped';
+    });
+
+    const duplicateDocIds = Array.from(counts.entries())
+        .filter(([, count]) => count > 1)
+        .map(([docId]) => docId);
+    const duplicateSet = new Set(duplicateDocIds);
+
+    mappings.forEach(row => {
+        if (row.selectedDocId && duplicateSet.has(row.selectedDocId)) {
+            row.status = 'duplicate';
+        }
+    });
+
+    return {
+        rows: mappings,
+        mappedCount,
+        skippedCount,
+        duplicateDocIds,
+        hasBlockingErrors: duplicateDocIds.length > 0,
+    };
+}
+
+function _renderFailureTable(container: HTMLElement | null | undefined, failures: IStoryEditContentFailure[]): void {
+    if (!container) return;
+
+    if (failures.length === 0) {
+        container.hidden = true;
+        container.innerHTML = '';
+        return;
+    }
+
+    const rowsHtml = failures.map(failure => `
+        <tr>
+            <td>${_escapeHtml(failure.chapterLabel)}</td>
+            <td>${_escapeHtml(failure.docName)}</td>
+            <td>${_escapeHtml(failure.reason)}</td>
+        </tr>
+    `).join('');
+
+    container.hidden = false;
+    container.innerHTML = `
+        <div class="ffne-story-bulk-results-title">Failed Replacements</div>
+        <table class="ffne-story-bulk-table" contenteditable="false">
+            <thead>
+                <tr>
+                    <th>Chapter</th>
+                    <th>Source Doc</th>
+                    <th>Reason</th>
+                </tr>
+            </thead>
+            <tbody>${rowsHtml}</tbody>
+        </table>
+    `;
+}
+
+export const StoryEditContent = {
+    MODULE_NAME: 'story-edit-content',
+    _state: null as StoryEditContentState | null,
+    _escHandler: null as ((e: KeyboardEvent) => void) | null,
+
+    init: function () {
+        const log = Core.getLogger(this.MODULE_NAME, 'init');
+        Core.onDomReady(() => {
+            const form = Core.getElement(Elements.STORY_EDIT_REPLACE_FORM) as HTMLFormElement | null;
+            if (!form) {
+                log('Replace form not found.');
+                return;
+            }
+            this.injectBulkReplaceButton(form);
+        });
+    },
+
+    injectBulkReplaceButton: function (form: HTMLFormElement) {
+        if (document.getElementById(BULK_REPLACE_BUTTON_ID)) return;
+
+        this._injectStyles();
+
+        const button = document.createElement('button');
+        button.id = BULK_REPLACE_BUTTON_ID;
+        button.type = 'button';
+        button.className = 'ffne-story-bulk-btn';
+        button.textContent = 'Bulk Replace';
+        button.addEventListener('click', () => this.openBulkReplaceModal());
+
+        const replaceControl = form.querySelector<HTMLElement>(
+            'input[name="action"][value="replace"], button[name="action"][value="replace"], input[type="submit"][value*="Replace"], button[type="submit"][value="replace"]'
+        );
+        if (replaceControl?.parentElement) {
+            replaceControl.insertAdjacentElement('afterend', button);
+        } else {
+            form.appendChild(button);
+        }
+    },
+
+    openBulkReplaceModal: function () {
+        if (document.getElementById(BULK_REPLACE_MODAL_ID)) return;
+
+        const replaceForm = Core.getElement(Elements.STORY_EDIT_REPLACE_FORM) as HTMLFormElement | null;
+        const chapterSelect = Core.getElement(Elements.STORY_EDIT_CHAPTER_SELECT) as HTMLSelectElement | null;
+        const docSelect = Core.getElement(Elements.STORY_EDIT_DOC_SELECT) as HTMLSelectElement | null;
+        const chapterRows = Core.getElements(Elements.STORY_EDIT_CHAPTER_ROWS);
+
+        const chapters = _parsePublishedChapters(chapterSelect, chapterRows);
+        const docs = _parseDocOptions(docSelect);
+        if (!replaceForm || chapters.length === 0 || docs.length === 0) {
+            return;
+        }
+
+        this._state = {
+            actionUrl: replaceForm.action || window.location.href,
+            chapters,
+            docs,
+            mappings: _createMappingRows(chapters),
+        };
+
+        const overlay = document.createElement('div');
+        overlay.id = BULK_REPLACE_MODAL_ID;
+        overlay.className = 'ffne-story-bulk-overlay';
+        overlay.innerHTML = `
+            <div class="ffne-story-bulk-modal" role="dialog" aria-modal="true" aria-labelledby="ffne-story-bulk-title">
+                <div class="ffne-story-bulk-header">
+                    <h3 id="ffne-story-bulk-title">Bulk Replace Chapters</h3>
+                    <button type="button" class="ffne-story-bulk-close" aria-label="Close">x</button>
+                </div>
+                <div class="ffne-story-bulk-body">
+                    <div id="ffne-story-bulk-summary" class="ffne-story-bulk-summary"></div>
+                    <table class="ffne-story-bulk-table" contenteditable="false">
+                        <thead>
+                            <tr>
+                                <th>Chapter</th>
+                                <th>Source Doc</th>
+                                <th>Status</th>
+                            </tr>
+                        </thead>
+                        <tbody id="ffne-story-bulk-rows"></tbody>
+                    </table>
+                    <div id="ffne-story-bulk-results" class="ffne-story-bulk-results" hidden></div>
+                    <div class="ffne-story-bulk-footer">
+                        <span id="ffne-story-bulk-status" class="ffne-story-bulk-run-status"></span>
+                        <button type="button" id="ffne-story-bulk-start" class="ffne-story-bulk-btn">Run Bulk Replace</button>
+                        <button type="button" class="ffne-story-bulk-btn" data-ffne-action="close">Close</button>
+                    </div>
+                </div>
+            </div>
+        `;
+
+        const rowsBody = overlay.querySelector<HTMLElement>('#ffne-story-bulk-rows');
+        const summary = overlay.querySelector<HTMLElement>('#ffne-story-bulk-summary');
+        const status = overlay.querySelector<HTMLElement>('#ffne-story-bulk-status');
+        const results = overlay.querySelector<HTMLElement>('#ffne-story-bulk-results');
+        const startButton = overlay.querySelector<HTMLButtonElement>('#ffne-story-bulk-start');
+
+        if (!rowsBody || !summary || !status || !results || !startButton || !this._state) return;
+
+        this._renderMappingRows(rowsBody, this._state.mappings, this._state.docs, () => {
+            this._refreshPlan(summary, startButton);
+            _renderFailureTable(results, []);
+            status.textContent = '';
+        });
+        this._refreshPlan(summary, startButton);
+        _renderFailureTable(results, []);
+
+        startButton.addEventListener('click', async (e) => {
+            if (!this._state) return;
+            const plan = _buildMappingPlan(this._state.mappings);
+            this._refreshPlan(summary, startButton);
+            if (plan.hasBlockingErrors || plan.mappedCount === 0) return;
+
+            const confirmed = confirm(
+                `Bulk Replace will replace ${plan.mappedCount} published chapter(s) using FFN's existing replace action.\n\n` +
+                'This cannot be undone from FFN Enhancements. Continue?'
+            );
+            if (!confirmed) return;
+
+            await this.runBulkReplace(e as MouseEvent, plan, status, results);
+            this._refreshPlan(summary, startButton);
+        });
+
+        overlay.querySelector<HTMLButtonElement>('.ffne-story-bulk-close')
+            ?.addEventListener('click', () => this.closeBulkReplaceModal());
+        overlay.querySelector<HTMLButtonElement>('[data-ffne-action="close"]')
+            ?.addEventListener('click', () => this.closeBulkReplaceModal());
+        overlay.addEventListener('click', (e) => {
+            if (e.target === overlay) this.closeBulkReplaceModal();
+        });
+
+        this._escHandler = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') this.closeBulkReplaceModal();
+        };
+        document.addEventListener('keydown', this._escHandler);
+        document.body.appendChild(overlay);
+    },
+
+    closeBulkReplaceModal: function () {
+        document.getElementById(BULK_REPLACE_MODAL_ID)?.remove();
+        if (this._escHandler) {
+            document.removeEventListener('keydown', this._escHandler);
+            this._escHandler = null;
+        }
+        this._state = null;
+    },
+
+    _injectStyles: function () {
+        if (document.getElementById(BULK_REPLACE_STYLE_ID)) return;
+
+        const style = document.createElement('style');
+        style.id = BULK_REPLACE_STYLE_ID;
+        style.textContent = `
+            .ffne-story-bulk-btn {
+                appearance: none;
+                border: 1px solid #7892ad;
+                background: #f0f4f8;
+                color: #234d73;
+                font-family: Verdana, Arial, sans-serif;
+                font-size: 12px;
+                line-height: 18px;
+                padding: 4px 10px;
+                border-radius: 3px;
+                cursor: pointer;
+                margin-left: 6px;
+            }
+            .ffne-story-bulk-overlay {
+                position: fixed;
+                inset: 0;
+                z-index: 99999;
+                background: rgba(0, 0, 0, 0.35);
+                font-family: Verdana, Arial, sans-serif;
+            }
+            .ffne-story-bulk-modal {
+                position: absolute;
+                left: 50%;
+                top: 50%;
+                transform: translate(-50%, -50%);
+                width: min(820px, calc(100vw - 32px));
+                max-height: min(760px, calc(100vh - 32px));
+                overflow: auto;
+                background: #fff;
+                border: 1px solid #7892ad;
+                box-shadow: 0 3px 18px rgba(0, 0, 0, 0.35);
+            }
+            .ffne-story-bulk-header {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                gap: 12px;
+                background: #336699;
+                color: #fff;
+                padding: 7px 10px;
+                border-bottom: 1px solid #254d73;
+            }
+            .ffne-story-bulk-header h3 {
+                margin: 0;
+                font-size: 13px;
+            }
+            .ffne-story-bulk-close {
+                appearance: none;
+                border: 0;
+                background: transparent;
+                color: #fff;
+                cursor: pointer;
+                font-size: 18px;
+                line-height: 18px;
+                padding: 0 4px;
+            }
+            .ffne-story-bulk-body {
+                padding: 12px;
+                color: #333;
+                font-size: 12px;
+            }
+            .ffne-story-bulk-summary {
+                margin-bottom: 10px;
+                padding: 7px 8px;
+                background: #f7f9fb;
+                border: 1px solid #d8e2ec;
+            }
+            .ffne-story-bulk-summary.ffne-story-bulk-error {
+                color: #8b0000;
+                background: #fff0f0;
+                border-color: #d8a0a0;
+            }
+            .ffne-story-bulk-table {
+                width: 100%;
+                border-collapse: collapse;
+            }
+            .ffne-story-bulk-table th,
+            .ffne-story-bulk-table td {
+                border: 1px solid #ddd;
+                padding: 5px 6px;
+                text-align: left;
+                vertical-align: top;
+            }
+            .ffne-story-bulk-table th {
+                background: #f0f4f8;
+            }
+            .ffne-story-bulk-row-running {
+                background: #fff4c2;
+            }
+            .ffne-story-bulk-row-success {
+                background: #edf9ed;
+            }
+            .ffne-story-bulk-row-failed {
+                background: #fff0f0;
+            }
+            .ffne-story-bulk-status-duplicate {
+                color: #8b0000;
+                font-weight: 700;
+            }
+            .ffne-story-bulk-footer {
+                display: flex;
+                justify-content: flex-end;
+                align-items: center;
+                gap: 8px;
+                margin-top: 10px;
+            }
+            .ffne-story-bulk-run-status {
+                margin-right: auto;
+                color: #555;
+            }
+            .ffne-story-bulk-results {
+                margin-top: 10px;
+                padding: 7px 8px;
+                color: #8b0000;
+                background: #fff0f0;
+                border: 1px solid #d8a0a0;
+            }
+            .ffne-story-bulk-results[hidden] {
+                display: none;
+            }
+            .ffne-story-bulk-results-title {
+                font-weight: 700;
+                margin-bottom: 6px;
+            }
+            .ffne-story-bulk-select {
+                width: 100%;
+                min-width: 200px;
+            }
+        `;
+        document.head.appendChild(style);
+    },
+
+    _renderMappingRows: function (
+        body: HTMLElement,
+        mappings: IStoryEditContentMappingRow[],
+        docs: IStoryEditContentDoc[],
+        onChange: () => void,
+    ) {
+        const optionsHtml = docs.map(doc => `<option value="${_escapeHtml(doc.docId)}">${_escapeHtml(doc.docName)}</option>`).join('');
+        body.innerHTML = mappings.map((mapping, index) => `
+            <tr data-row-index="${index}">
+                <td>${_escapeHtml(mapping.chapter.chapterLabel)}</td>
+                <td>
+                    <select class="ffne-story-bulk-select" data-row-index="${index}">
+                        <option value="">Skip this chapter</option>
+                        ${optionsHtml}
+                    </select>
+                </td>
+                <td data-ffne-status>${mapping.status}</td>
+            </tr>
+        `).join('');
+
+        body.querySelectorAll<HTMLTableRowElement>('tr[data-row-index]').forEach(row => {
+            const index = Number.parseInt(row.getAttribute('data-row-index') || '-1', 10);
+            if (Number.isInteger(index) && mappings[index]) {
+                mappings[index].modalRow = row;
+                this._renderRowStatus(mappings[index]);
+            }
+        });
+
+        body.querySelectorAll<HTMLSelectElement>('select[data-row-index]').forEach(select => {
+            select.addEventListener('change', () => {
+                const rowIndex = Number.parseInt(select.getAttribute('data-row-index') || '-1', 10);
+                if (!Number.isInteger(rowIndex) || !this._state) return;
+                _setManualDocSelection(this._state.mappings, this._state.docs, rowIndex, select.value);
+                this._state.mappings.forEach(row => this._renderRowStatus(row));
+                this._syncSelectValues(body, this._state.mappings);
+                onChange();
+            });
+        });
+    },
+
+    _syncSelectValues: function (body: HTMLElement, mappings: IStoryEditContentMappingRow[]) {
+        body.querySelectorAll<HTMLSelectElement>('select[data-row-index]').forEach(select => {
+            const rowIndex = Number.parseInt(select.getAttribute('data-row-index') || '-1', 10);
+            if (!Number.isInteger(rowIndex) || !mappings[rowIndex]) return;
+            select.value = mappings[rowIndex].selectedDocId;
+        });
+    },
+
+    _renderRowStatus: function (mapping: IStoryEditContentMappingRow) {
+        if (!mapping.modalRow) return;
+
+        mapping.modalRow.classList.remove('ffne-story-bulk-row-running', 'ffne-story-bulk-row-success', 'ffne-story-bulk-row-failed');
+        if (mapping.status === 'running') mapping.modalRow.classList.add('ffne-story-bulk-row-running');
+        if (mapping.status === 'success') mapping.modalRow.classList.add('ffne-story-bulk-row-success');
+        if (mapping.status === 'failed') mapping.modalRow.classList.add('ffne-story-bulk-row-failed');
+
+        const statusCell = mapping.modalRow.querySelector<HTMLElement>('[data-ffne-status]');
+        if (!statusCell) return;
+
+        statusCell.classList.toggle('ffne-story-bulk-status-duplicate', mapping.status === 'duplicate');
+        if (mapping.status === 'skipped' || mapping.status === 'unmapped') {
+            statusCell.textContent = 'Skipped';
+        } else if (mapping.status === 'mapped') {
+            statusCell.textContent = mapping.source === 'autofill' ? 'Autofilled' : 'Mapped';
+        } else if (mapping.status === 'duplicate') {
+            statusCell.textContent = 'Duplicate doc';
+        } else if (mapping.status === 'running') {
+            statusCell.textContent = 'Running';
+        } else if (mapping.status === 'success') {
+            statusCell.textContent = 'Done';
+        } else if (mapping.status === 'failed') {
+            statusCell.textContent = 'Failed';
+        }
+    },
+
+    _refreshPlan: function (summary: HTMLElement, startButton: HTMLButtonElement) {
+        if (!this._state) return;
+        const plan = _buildMappingPlan(this._state.mappings);
+        const summaryClass = plan.hasBlockingErrors
+            ? 'ffne-story-bulk-summary ffne-story-bulk-error'
+            : 'ffne-story-bulk-summary';
+        summary.className = summaryClass;
+        summary.innerHTML = `
+            <div>
+                <strong>${plan.mappedCount}</strong> mapped,
+                <strong>${plan.skippedCount}</strong> skipped,
+                <strong>${plan.duplicateDocIds.length}</strong> duplicate mapping(s).
+            </div>
+            ${plan.hasBlockingErrors ? '<div>Each source doc can be used only once.</div>' : ''}
+        `;
+        startButton.disabled = plan.hasBlockingErrors || plan.mappedCount === 0;
+        this._state.mappings.forEach(row => this._renderRowStatus(row));
+    },
+
+    runBulkReplace: async function (
+        e: MouseEvent,
+        plan?: IStoryEditContentPlan,
+        statusEl?: HTMLElement,
+        resultsEl?: HTMLElement,
+    ) {
+        if (!this._state) return;
+
+        const activePlan = plan || _buildMappingPlan(this._state.mappings);
+        const failures: IStoryEditContentFailure[] = [];
+        const failureReasons = new Map<string, string>();
+        const mappedRows = activePlan.rows.filter(row => !!row.selectedDocId && row.status !== 'duplicate');
+
+        if (activePlan.hasBlockingErrors || mappedRows.length === 0) {
+            if (statusEl) {
+                statusEl.textContent = activePlan.hasBlockingErrors
+                    ? 'Bulk Replace blocked by duplicate doc mappings.'
+                    : 'No chapters are mapped.';
+            }
+            _renderFailureTable(resultsEl, []);
+            return;
+        }
+
+        const setFailure = (row: IStoryEditContentMappingRow, reason: string) => {
+            failureReasons.set(row.chapter.storyTextId, reason);
+        };
+
+        const config: IBulkOperationConfig<IStoryEditContentMappingRow> = {
+            verb: 'Replace',
+            getItems: () => mappedRows,
+            onItemStart: (row, pass, index, total) => {
+                row.status = 'running';
+                this._renderRowStatus(row);
+                if (statusEl) {
+                    const action = pass === 2 ? 'Retrying' : 'Replacing';
+                    statusEl.textContent = `${action} ${index}/${total}: ${row.chapter.chapterLabel} from ${row.selectedDocName}...`;
+                }
+            },
+            processItem: async (row) => {
+                row.status = 'running';
+                this._renderRowStatus(row);
+
+                const validation = await DocFetchService.validatePrivateDocHasContentWithResult(row.selectedDocId, row.selectedDocName);
+                if (!validation.ok) {
+                    setFailure(row, validation.reason || 'Source document validation failed.');
+                    return false;
+                }
+
+                const result = await StoryReplaceService.submitReplaceForm(
+                    this._state?.actionUrl || window.location.href,
+                    row.chapter.storyTextId,
+                    row.selectedDocId,
+                );
+                if (!result.ok) {
+                    setFailure(row, result.reason || 'FFN did not confirm the replacement.');
+                    return false;
+                }
+
+                failureReasons.delete(row.chapter.storyTextId);
+                return true;
+            },
+            onItemSuccess: (row) => {
+                row.status = 'success';
+                this._renderRowStatus(row);
+            },
+            onPermanentFailure: (row) => {
+                row.status = 'failed';
+                this._renderRowStatus(row);
+                failures.push({
+                    chapterLabel: row.chapter.chapterLabel,
+                    docName: row.selectedDocName,
+                    reason: failureReasons.get(row.chapter.storyTextId) || 'Replace failed after retry.',
+                });
+            },
+            onFinalize: ({ successCount, totalCount }) => {
+                _renderFailureTable(resultsEl, failures);
+                if (statusEl) {
+                    if (successCount === totalCount) {
+                        statusEl.textContent = `Replaced all ${successCount} chapter(s).`;
+                    } else if (successCount > 0) {
+                        statusEl.textContent = `Replaced ${successCount}; failed ${totalCount - successCount}.`;
+                    } else {
+                        statusEl.textContent = 'No chapters were replaced.';
+                    }
+                }
+            },
+        };
+
+        await runBulkOperation(e, config);
+    },
+
+    _parsePublishedChapters,
+    _parseDocOptions,
+    _createMappingRows,
+    _setManualDocSelection,
+    _applySemanticAutofill,
+    _buildMappingPlan,
+    _renderFailureTable,
+    _submitStoryReplaceForm: StoryReplaceService.submitReplaceForm,
+};

--- a/src/modules/StoryEditContent.ts
+++ b/src/modules/StoryEditContent.ts
@@ -33,6 +33,13 @@ function _normalizeText(value: string): string {
     return value.replace(/\s+/g, ' ').trim();
 }
 
+function _parseFfnOptionName(value: string): string {
+    return _normalizeText(value)
+        .replace(/^\d+\.\s*/, '')
+        .replace(/\s*\([\d,]+\)\s*$/, '')
+        .trim();
+}
+
 function _escapeHtml(value: string): string {
     return value
         .replace(/&/g, '&amp;')
@@ -77,9 +84,11 @@ function _parsePublishedChapters(
     if (!chapterSelect) return [];
 
     const options = Array.from(chapterSelect.options)
-        .map((option, index) => ({ option, index }))
-        .filter(({ option }) => !!option.value.trim())
-        .map(({ option, index }) => ({
+        .filter((option) => {
+            const value = option.value.trim();
+            return !!value && value !== '0';
+        })
+        .map((option, index) => ({
             storyTextId: option.value.trim(),
             chapterNumber: _extractChapterNumber(option.textContent || option.label || '', index + 1),
             chapterLabel: _normalizeText(option.textContent || option.label || `Chapter ${index + 1}`),
@@ -144,8 +153,8 @@ function _parseDocOptions(docSelect: HTMLSelectElement | null): IStoryEditConten
     const docs: IStoryEditContentDoc[] = [];
     for (const option of Array.from(docSelect.options)) {
         const docId = option.value.trim();
-        const docName = _normalizeText(option.textContent || option.label || '');
-        if (!docId || !docName || seen.has(docId)) continue;
+        const docName = _parseFfnOptionName(option.textContent || option.label || '');
+        if (!docId || docId === '0' || !docName || seen.has(docId)) continue;
         seen.add(docId);
         docs.push({ docId, docName });
     }
@@ -343,7 +352,7 @@ export const StoryEditContent = {
         button.addEventListener('click', () => this.openBulkReplaceModal());
 
         const replaceControl = form.querySelector<HTMLElement>(
-            'input[name="action"][value="replace"], button[name="action"][value="replace"], input[type="submit"][value*="Replace"], button[type="submit"][value="replace"]'
+            'button[type="submit"], input[type="submit"]'
         );
         if (replaceControl?.parentElement) {
             replaceControl.insertAdjacentElement('afterend', button);

--- a/src/modules/StoryEditContent.ts
+++ b/src/modules/StoryEditContent.ts
@@ -12,6 +12,7 @@ import { Core } from './Core';
 import { DocFetchService } from '../services/DocFetchService';
 import { StoryReplaceService } from '../services/StoryReplaceService';
 import { runBulkOperation } from '../utils/runBulkOperation';
+import { SettingsManager } from './SettingsManager';
 
 const BULK_REPLACE_BUTTON_ID = 'ffne-story-bulk-replace-btn';
 const BULK_REPLACE_MODAL_ID = 'ffne-story-bulk-replace-modal';
@@ -184,14 +185,19 @@ function _applySemanticAutofill(
     anchorIndex: number,
     selectedDocId: string,
 ): IStoryEditContentMappingRow[] {
+    const log = Core.getLogger('story-edit-content', '_applySemanticAutofill');
     const anchor = mappings[anchorIndex];
     if (!anchor || !selectedDocId) return mappings;
 
     const { byId, byName } = _buildDocMaps(docs);
     const anchorDoc = byId.get(selectedDocId);
     const parsed = anchorDoc ? _parseSemanticDocName(anchorDoc.docName) : null;
-    if (!anchorDoc || !parsed) return mappings;
+    if (!anchorDoc || !parsed) {
+        log(`No semantic doc suffix found for selected doc "${anchorDoc?.docName || selectedDocId}".`);
+        return mappings;
+    }
 
+    let appliedCount = 0;
     for (let index = 0; index < mappings.length; index++) {
         if (index === anchorIndex) continue;
 
@@ -211,7 +217,13 @@ function _applySemanticAutofill(
         row.source = 'autofill';
         row.hasBeenAutofilled = true;
         row.status = 'mapped';
+        appliedCount++;
     }
+
+    log(`Autofill from "${anchorDoc.docName}" applied to ${appliedCount} row(s).`, {
+        anchorIndex,
+        anchorChapter: anchor.chapter.chapterNumber,
+    });
 
     return mappings;
 }
@@ -232,8 +244,14 @@ function _setManualDocSelection(
     row.source = doc ? 'manual' : 'unmapped';
     row.status = doc ? 'mapped' : 'unmapped';
 
-    if (doc) {
+    const log = Core.getLogger('story-edit-content', '_setManualDocSelection');
+    if (doc && SettingsManager.get('bulkReplaceAutofill')) {
+        log(`Manual selection "${doc.docName}" on row ${rowIndex}; running semantic autofill.`);
         _applySemanticAutofill(mappings, docs, rowIndex, doc.docId);
+    } else if (doc) {
+        log(`Manual selection "${doc.docName}" on row ${rowIndex}; semantic autofill disabled.`);
+    } else {
+        log(`Row ${rowIndex} unmapped by manual selection.`);
     }
 
     return mappings;
@@ -317,44 +335,53 @@ export const StoryEditContent = {
     init: function () {
         const log = Core.getLogger(this.MODULE_NAME, 'init');
         Core.onDomReady(() => {
+            log('Initializing StoryEditContent hooks.');
             const form = Core.getElement(Elements.STORY_EDIT_REPLACE_FORM) as HTMLFormElement | null;
             if (!form) {
                 log('Replace form not found.');
                 return;
             }
             this.injectBulkReplaceButton(form);
+            log('StoryEditContent hooks initialized.');
         });
     },
 
     injectBulkReplaceButton: function (form: HTMLFormElement) {
         if (document.getElementById(BULK_REPLACE_BUTTON_ID)) return;
+        const log = Core.getLogger(this.MODULE_NAME, 'injectBulkReplaceButton');
 
         this._injectStyles();
 
-        const button = document.createElement('button');
-        button.id = BULK_REPLACE_BUTTON_ID;
-        button.type = 'button';
-        button.className = 'ffne-story-bulk-btn';
-        button.textContent = 'Bulk Replace';
-        button.addEventListener('click', () => this.openBulkReplaceModal());
+        const trigger = document.createElement('a');
+        trigger.id = BULK_REPLACE_BUTTON_ID;
+        trigger.href = '#';
+        trigger.textContent = 'Bulk Replace';
+        trigger.addEventListener('click', event => {
+            event.preventDefault();
+            this.openBulkReplaceModal();
+        });
 
         const replaceToggle = Core.getElement(Elements.STORY_EDIT_REPLACE_TOGGLE) as HTMLAnchorElement | null;
         if (replaceToggle?.parentElement) {
-            const spacer = document.createTextNode(' ');
-            replaceToggle.after(spacer, button);
+            const separator = document.createTextNode(' | ');
+            replaceToggle.after(separator, trigger);
+            log('Bulk Replace link inserted next to visible Replace/Update toggle.');
             return;
         }
 
         const replaceControl = Core.getElement(Elements.STORY_EDIT_REPLACE_SUBMIT) as HTMLElement | null;
         if (replaceControl) {
-            replaceControl.insertAdjacentElement('afterend', button);
+            replaceControl.insertAdjacentElement('afterend', trigger);
+            log('Bulk Replace link inserted after native replace submit control.');
         } else {
-            form.appendChild(button);
+            form.appendChild(trigger);
+            log('Bulk Replace link appended to native replace form.');
         }
     },
 
     openBulkReplaceModal: function () {
         if (document.getElementById(BULK_REPLACE_MODAL_ID)) return;
+        const log = Core.getLogger(this.MODULE_NAME, 'openBulkReplaceModal');
 
         const replaceForm = Core.getElement(Elements.STORY_EDIT_REPLACE_FORM) as HTMLFormElement | null;
         const chapterSelect = Core.getElement(Elements.STORY_EDIT_CHAPTER_SELECT) as HTMLSelectElement | null;
@@ -364,8 +391,14 @@ export const StoryEditContent = {
         const chapters = _parsePublishedChapters(chapterSelect, chapterRows);
         const docs = _parseDocOptions(docSelect);
         if (!replaceForm || chapters.length === 0 || docs.length === 0) {
+            log('Bulk Replace modal blocked by missing page data.', {
+                hasReplaceForm: !!replaceForm,
+                chapterCount: chapters.length,
+                docCount: docs.length,
+            });
             return;
         }
+        log(`Opening Bulk Replace modal for ${chapters.length} chapter(s) and ${docs.length} doc(s).`);
 
         this._state = {
             actionUrl: replaceForm.action || window.location.href,
@@ -676,6 +709,8 @@ export const StoryEditContent = {
     _refreshPlan: function (summary: HTMLElement, startButton: HTMLButtonElement) {
         if (!this._state) return;
         const plan = _buildMappingPlan(this._state.mappings);
+        const log = Core.getLogger(this.MODULE_NAME, '_refreshPlan');
+        log(`Plan refreshed: ${plan.mappedCount} mapped, ${plan.skippedCount} skipped, ${plan.duplicateDocIds.length} duplicate(s).`);
         const summaryClass = plan.hasBlockingErrors
             ? 'ffne-story-bulk-summary ffne-story-bulk-error'
             : 'ffne-story-bulk-summary';
@@ -699,11 +734,16 @@ export const StoryEditContent = {
         resultsEl?: HTMLElement,
     ) {
         if (!this._state) return;
+        const log = Core.getLogger(this.MODULE_NAME, 'runBulkReplace');
 
         const activePlan = plan || _buildMappingPlan(this._state.mappings);
         const failures: IStoryEditContentFailure[] = [];
         const failureReasons = new Map<string, string>();
         const mappedRows = activePlan.rows.filter(row => !!row.selectedDocId && row.status !== 'duplicate');
+        log(`Bulk Replace requested for ${mappedRows.length} mapped row(s).`, {
+            hasBlockingErrors: activePlan.hasBlockingErrors,
+            duplicateDocIds: activePlan.duplicateDocIds,
+        });
 
         if (activePlan.hasBlockingErrors || mappedRows.length === 0) {
             if (statusEl) {
@@ -712,6 +752,7 @@ export const StoryEditContent = {
                     : 'No chapters are mapped.';
             }
             _renderFailureTable(resultsEl, []);
+            log('Bulk Replace blocked before execution.');
             return;
         }
 
@@ -736,9 +777,11 @@ export const StoryEditContent = {
 
                 const validation = await DocFetchService.validatePrivateDocHasContentWithResult(row.selectedDocId, row.selectedDocName);
                 if (!validation.ok) {
+                    log(`Source doc validation failed for "${row.selectedDocName}".`, validation.reason);
                     setFailure(row, validation.reason || 'Source document validation failed.');
                     return false;
                 }
+                log(`Source doc validation passed for "${row.selectedDocName}".`);
 
                 const result = await StoryReplaceService.submitReplaceForm(
                     this._state?.actionUrl || window.location.href,
@@ -746,10 +789,12 @@ export const StoryEditContent = {
                     row.selectedDocId,
                 );
                 if (!result.ok) {
+                    log(`Replace failed for "${row.chapter.chapterLabel}" from "${row.selectedDocName}".`, result.reason);
                     setFailure(row, result.reason || 'FFN did not confirm the replacement.');
                     return false;
                 }
 
+                log(`Replace succeeded for "${row.chapter.chapterLabel}" from "${row.selectedDocName}".`);
                 failureReasons.delete(row.chapter.storyTextId);
                 return true;
             },
@@ -765,9 +810,11 @@ export const StoryEditContent = {
                     docName: row.selectedDocName,
                     reason: failureReasons.get(row.chapter.storyTextId) || 'Replace failed after retry.',
                 });
+                log(`Permanent replace failure for "${row.chapter.chapterLabel}".`, failures[failures.length - 1].reason);
             },
             onFinalize: ({ successCount, totalCount }) => {
                 _renderFailureTable(resultsEl, failures);
+                log(`Bulk Replace finalized: ${successCount}/${totalCount} succeeded.`);
                 if (statusEl) {
                     if (successCount === totalCount) {
                         statusEl.textContent = `Replaced all ${successCount} chapter(s).`;

--- a/src/services/DocFetchService.ts
+++ b/src/services/DocFetchService.ts
@@ -103,6 +103,27 @@ export const DocFetchService = {
     },
 
     /**
+     * Validates that a private source document exists and contains non-empty editor content.
+     */
+    validatePrivateDocHasContentWithResult: async function (docId: string, title: string): Promise<PrivateDocSaveResult> {
+        const doc = await this._fetchDocPage(docId, title);
+        if (!doc) {
+            return { ok: false, reason: 'Could not load the source document.' };
+        }
+
+        const trimmedContent = this._getEditorContentForGuard(doc);
+        if (trimmedContent === null) {
+            return { ok: false, reason: 'Could not find the source document editor content.' };
+        }
+
+        if (!trimmedContent) {
+            return { ok: false, reason: 'Source document is empty.' };
+        }
+
+        return { ok: true };
+    },
+
+    /**
      * Reads the backing editor textarea used by FFN private documents.
      * Returns null when the editor was not present, and trimmed content otherwise.
      */

--- a/src/services/StoryReplaceService.ts
+++ b/src/services/StoryReplaceService.ts
@@ -1,0 +1,30 @@
+export interface StoryReplaceResult {
+    ok: boolean;
+    reason?: string;
+}
+
+export const StoryReplaceService = {
+    submitReplaceForm: async function (actionUrl: string, storyTextId: string, docId: string): Promise<StoryReplaceResult> {
+        const body = new URLSearchParams({
+            storytextid: storyTextId,
+            docid: docId,
+            action: 'replace',
+        });
+
+        const response = await fetch(actionUrl, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+            },
+            body: body.toString(),
+        });
+
+        if (!response.ok) {
+            return { ok: false, reason: `Replace request failed with HTTP ${response.status}.` };
+        }
+
+        await response.text();
+        return { ok: true };
+    },
+};

--- a/src/services/StoryReplaceService.ts
+++ b/src/services/StoryReplaceService.ts
@@ -1,4 +1,6 @@
 import { SettingsManager } from '../modules/SettingsManager';
+import { Elements } from '../enums/Elements';
+import { StoryEditContentDelegate } from '../delegates/StoryEditContentDelegate';
 
 export interface StoryReplaceResult {
     ok: boolean;
@@ -16,26 +18,14 @@ function appendHiddenInput(form: HTMLFormElement, name: string, value: string): 
     return input;
 }
 
-function findReplaceForm(doc: Document): HTMLFormElement | null {
-    const forms = Array.from(doc.forms);
-    return forms.find(form => {
-        const chapterSelect = form.querySelector('select[name="storytextid"]');
-        const docSelect = form.querySelector('select[name="docid"]');
-        const replaceAction = form.querySelector('input[name="action"][value="replace"], button[name="action"][value="replace"]');
-        return !!chapterSelect && !!docSelect && !!replaceAction;
-    }) || null;
-}
-
-function setFormValue(form: HTMLFormElement, name: string, value: string): boolean {
-    const control = form.elements.namedItem(name);
+function setControlValue(control: Element | null, value: string): boolean {
     if (control && 'value' in control) {
         const valueControl = control as HTMLInputElement | HTMLSelectElement | RadioNodeList;
         valueControl.value = value;
         return valueControl.value === value;
     }
 
-    appendHiddenInput(form, name, value);
-    return true;
+    return false;
 }
 
 function normalizeText(value: string): string {
@@ -43,7 +33,7 @@ function normalizeText(value: string): string {
 }
 
 function getExplicitFailureReason(doc: Document): string | null {
-    const failure = doc.querySelector('.panel_error, .gui_error, .alert-error, .error');
+    const failure = StoryEditContentDelegate.getElement(Elements.STORY_EDIT_ERROR_PANEL, doc);
     const failureText = normalizeText(failure?.textContent || '');
     if (failureText) return failureText;
 
@@ -95,14 +85,19 @@ export const StoryReplaceService = {
             };
 
             const submitNativeReplaceForm = (doc: Document): StoryReplaceResult | null => {
-                const form = findReplaceForm(doc);
+                const form = StoryEditContentDelegate.getElement(Elements.STORY_EDIT_REPLACE_FORM, doc) as HTMLFormElement | null;
                 if (!form) {
                     return { ok: false, reason: 'Hidden StoryEditContent page did not contain the native replace form.' };
                 }
 
-                const didSetChapter = setFormValue(form, 'storytextid', storyTextId);
-                const didSetDoc = setFormValue(form, 'docid', docId);
-                setFormValue(form, 'action', 'replace');
+                const chapterSelect = StoryEditContentDelegate.getElement(Elements.STORY_EDIT_CHAPTER_SELECT, doc);
+                const docSelect = StoryEditContentDelegate.getElement(Elements.STORY_EDIT_DOC_SELECT, doc);
+                const actionControl = StoryEditContentDelegate.getElement(Elements.STORY_EDIT_REPLACE_ACTION_CONTROL, doc);
+                const didSetChapter = setControlValue(chapterSelect, storyTextId);
+                const didSetDoc = setControlValue(docSelect, docId);
+                if (!setControlValue(actionControl, 'replace')) {
+                    appendHiddenInput(form, 'action', 'replace');
+                }
 
                 if (!didSetChapter) {
                     return { ok: false, reason: 'Hidden replace form did not include the selected chapter.' };

--- a/src/services/StoryReplaceService.ts
+++ b/src/services/StoryReplaceService.ts
@@ -1,6 +1,7 @@
 import { SettingsManager } from '../modules/SettingsManager';
 import { Elements } from '../enums/Elements';
 import { StoryEditContentDelegate } from '../delegates/StoryEditContentDelegate';
+import { Core } from '../modules/Core';
 
 export interface StoryReplaceResult {
     ok: boolean;
@@ -47,11 +48,14 @@ function getExplicitFailureReason(doc: Document): string | null {
 
 export const StoryReplaceService = {
     submitReplaceForm: async function (actionUrl: string, storyTextId: string, docId: string): Promise<StoryReplaceResult> {
+        const log = Core.getLogger('StoryReplaceService', 'submitReplaceForm');
         if (!storyTextId || !docId) {
+            log('Replace submission blocked by missing chapter or source doc.', { storyTextId, docId });
             return { ok: false, reason: 'Missing chapter or source document selection.' };
         }
 
         return new Promise<StoryReplaceResult>((resolve) => {
+            log(`Loading hidden StoryEditContent page for chapter ${storyTextId} and doc ${docId}.`, actionUrl);
             const iframe = document.createElement('iframe');
             iframe.name = `ffne_story_replace_${Date.now()}_${Math.random().toString(36).slice(2)}`;
             iframe.style.position = 'absolute';
@@ -75,18 +79,23 @@ export const StoryReplaceService = {
             const resolveOnce = (result: StoryReplaceResult) => {
                 if (settled) return;
                 settled = true;
+                log(`Hidden replace flow resolved: ${result.ok ? 'success' : 'failure'}.`, result.reason);
                 cleanup();
                 resolve(result);
             };
 
             const armTimeout = (ms: number, reason: string) => {
                 if (timeoutId !== null) window.clearTimeout(timeoutId);
-                timeoutId = window.setTimeout(() => resolveOnce({ ok: false, reason }), ms);
+                timeoutId = window.setTimeout(() => {
+                    log('Hidden replace flow timed out.', reason);
+                    resolveOnce({ ok: false, reason });
+                }, ms);
             };
 
             const submitNativeReplaceForm = (doc: Document): StoryReplaceResult | null => {
                 const form = StoryEditContentDelegate.getElement(Elements.STORY_EDIT_REPLACE_FORM, doc) as HTMLFormElement | null;
                 if (!form) {
+                    log('Native replace form missing from hidden StoryEditContent page.');
                     return { ok: false, reason: 'Hidden StoryEditContent page did not contain the native replace form.' };
                 }
 
@@ -100,9 +109,11 @@ export const StoryReplaceService = {
                 }
 
                 if (!didSetChapter) {
+                    log('Hidden replace form did not accept selected chapter.', storyTextId);
                     return { ok: false, reason: 'Hidden replace form did not include the selected chapter.' };
                 }
                 if (!didSetDoc) {
+                    log('Hidden replace form did not accept selected source doc.', docId);
                     return { ok: false, reason: 'Hidden replace form did not include the selected source document.' };
                 }
 
@@ -112,6 +123,7 @@ export const StoryReplaceService = {
                     `No replace response returned within ${SettingsManager.get('iframeSaveTimeoutMs')}ms.`,
                 );
 
+                log('Submitting native replace form inside hidden StoryEditContent page.');
                 form.submit();
                 return null;
             };
@@ -120,6 +132,7 @@ export const StoryReplaceService = {
                 try {
                     const doc = iframe.contentDocument;
                     if (!doc) {
+                        log('Hidden StoryEditContent iframe had no readable document.');
                         resolveOnce({ ok: false, reason: 'Hidden StoryEditContent frame was not readable.' });
                         return;
                     }
@@ -128,6 +141,7 @@ export const StoryReplaceService = {
                     if (phase === 'loading-page') {
                         if (!frameHref || frameHref === 'about:blank') return;
 
+                        log('Hidden StoryEditContent page loaded; preparing native replace form.', frameHref);
                         const submitFailure = submitNativeReplaceForm(doc);
                         if (submitFailure) resolveOnce(submitFailure);
                         return;
@@ -136,14 +150,17 @@ export const StoryReplaceService = {
                     if (phase === 'submitting-replace') {
                         const failureReason = getExplicitFailureReason(doc);
                         if (failureReason) {
+                            log('Hidden replace response contained an explicit failure.', failureReason);
                             resolveOnce({ ok: false, reason: failureReason });
                             return;
                         }
 
+                        log('Hidden replace response loaded without explicit failure.');
                         resolveOnce({ ok: true });
                     }
                 } catch (err) {
                     const message = err instanceof Error ? err.message : String(err);
+                    log('Could not inspect hidden StoryEditContent frame.', message);
                     resolveOnce({ ok: false, reason: `Could not inspect hidden StoryEditContent frame: ${message}` });
                 }
             };
@@ -159,6 +176,7 @@ export const StoryReplaceService = {
                 iframe.src = new URL(actionUrl, window.location.href).href;
             } catch (err) {
                 const message = err instanceof Error ? err.message : String(err);
+                log('Could not load hidden StoryEditContent page.', message);
                 resolveOnce({ ok: false, reason: `Could not load hidden StoryEditContent page: ${message}` });
             }
         });

--- a/src/services/StoryReplaceService.ts
+++ b/src/services/StoryReplaceService.ts
@@ -1,30 +1,171 @@
+import { SettingsManager } from '../modules/SettingsManager';
+
 export interface StoryReplaceResult {
     ok: boolean;
     reason?: string;
 }
 
+type ReplacePhase = 'loading-page' | 'submitting-replace';
+
+function appendHiddenInput(form: HTMLFormElement, name: string, value: string): HTMLInputElement {
+    const input = form.ownerDocument.createElement('input');
+    input.type = 'hidden';
+    input.name = name;
+    input.value = value;
+    form.appendChild(input);
+    return input;
+}
+
+function findReplaceForm(doc: Document): HTMLFormElement | null {
+    const forms = Array.from(doc.forms);
+    return forms.find(form => {
+        const chapterSelect = form.querySelector('select[name="storytextid"]');
+        const docSelect = form.querySelector('select[name="docid"]');
+        const replaceAction = form.querySelector('input[name="action"][value="replace"], button[name="action"][value="replace"]');
+        return !!chapterSelect && !!docSelect && !!replaceAction;
+    }) || null;
+}
+
+function setFormValue(form: HTMLFormElement, name: string, value: string): boolean {
+    const control = form.elements.namedItem(name);
+    if (control && 'value' in control) {
+        const valueControl = control as HTMLInputElement | HTMLSelectElement | RadioNodeList;
+        valueControl.value = value;
+        return valueControl.value === value;
+    }
+
+    appendHiddenInput(form, name, value);
+    return true;
+}
+
+function normalizeText(value: string): string {
+    return value.replace(/\s+/g, ' ').trim();
+}
+
+function getExplicitFailureReason(doc: Document): string | null {
+    const failure = doc.querySelector('.panel_error, .gui_error, .alert-error, .error');
+    const failureText = normalizeText(failure?.textContent || '');
+    if (failureText) return failureText;
+
+    const bodyText = normalizeText(doc.body?.textContent || '');
+    if (/please\s+log\s*in|login\s+required|not\s+authorized/i.test(bodyText)) {
+        return 'FFN returned a login or authorization page.';
+    }
+
+    return null;
+}
+
 export const StoryReplaceService = {
     submitReplaceForm: async function (actionUrl: string, storyTextId: string, docId: string): Promise<StoryReplaceResult> {
-        const body = new URLSearchParams({
-            storytextid: storyTextId,
-            docid: docId,
-            action: 'replace',
-        });
-
-        const response = await fetch(actionUrl, {
-            method: 'POST',
-            credentials: 'same-origin',
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
-            },
-            body: body.toString(),
-        });
-
-        if (!response.ok) {
-            return { ok: false, reason: `Replace request failed with HTTP ${response.status}.` };
+        if (!storyTextId || !docId) {
+            return { ok: false, reason: 'Missing chapter or source document selection.' };
         }
 
-        await response.text();
-        return { ok: true };
+        return new Promise<StoryReplaceResult>((resolve) => {
+            const iframe = document.createElement('iframe');
+            iframe.name = `ffne_story_replace_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+            iframe.style.position = 'absolute';
+            iframe.style.width = '1px';
+            iframe.style.height = '1px';
+            iframe.style.left = '-9999px';
+            iframe.style.top = '-9999px';
+            iframe.style.border = 'none';
+            iframe.style.visibility = 'hidden';
+
+            let settled = false;
+            let phase: ReplacePhase = 'loading-page';
+            let timeoutId: number | null = null;
+
+            const cleanup = () => {
+                if (timeoutId !== null) window.clearTimeout(timeoutId);
+                iframe.removeEventListener('load', onLoad);
+                iframe.remove();
+            };
+
+            const resolveOnce = (result: StoryReplaceResult) => {
+                if (settled) return;
+                settled = true;
+                cleanup();
+                resolve(result);
+            };
+
+            const armTimeout = (ms: number, reason: string) => {
+                if (timeoutId !== null) window.clearTimeout(timeoutId);
+                timeoutId = window.setTimeout(() => resolveOnce({ ok: false, reason }), ms);
+            };
+
+            const submitNativeReplaceForm = (doc: Document): StoryReplaceResult | null => {
+                const form = findReplaceForm(doc);
+                if (!form) {
+                    return { ok: false, reason: 'Hidden StoryEditContent page did not contain the native replace form.' };
+                }
+
+                const didSetChapter = setFormValue(form, 'storytextid', storyTextId);
+                const didSetDoc = setFormValue(form, 'docid', docId);
+                setFormValue(form, 'action', 'replace');
+
+                if (!didSetChapter) {
+                    return { ok: false, reason: 'Hidden replace form did not include the selected chapter.' };
+                }
+                if (!didSetDoc) {
+                    return { ok: false, reason: 'Hidden replace form did not include the selected source document.' };
+                }
+
+                phase = 'submitting-replace';
+                armTimeout(
+                    SettingsManager.get('iframeSaveTimeoutMs'),
+                    `No replace response returned within ${SettingsManager.get('iframeSaveTimeoutMs')}ms.`,
+                );
+
+                form.submit();
+                return null;
+            };
+
+            const onLoad = () => {
+                try {
+                    const doc = iframe.contentDocument;
+                    if (!doc) {
+                        resolveOnce({ ok: false, reason: 'Hidden StoryEditContent frame was not readable.' });
+                        return;
+                    }
+
+                    const frameHref = iframe.contentWindow?.location.href || '';
+                    if (phase === 'loading-page') {
+                        if (!frameHref || frameHref === 'about:blank') return;
+
+                        const submitFailure = submitNativeReplaceForm(doc);
+                        if (submitFailure) resolveOnce(submitFailure);
+                        return;
+                    }
+
+                    if (phase === 'submitting-replace') {
+                        const failureReason = getExplicitFailureReason(doc);
+                        if (failureReason) {
+                            resolveOnce({ ok: false, reason: failureReason });
+                            return;
+                        }
+
+                        resolveOnce({ ok: true });
+                    }
+                } catch (err) {
+                    const message = err instanceof Error ? err.message : String(err);
+                    resolveOnce({ ok: false, reason: `Could not inspect hidden StoryEditContent frame: ${message}` });
+                }
+            };
+
+            iframe.addEventListener('load', onLoad);
+            document.body.appendChild(iframe);
+
+            try {
+                armTimeout(
+                    SettingsManager.get('iframeLoadTimeoutMs'),
+                    `Hidden StoryEditContent page did not load within ${SettingsManager.get('iframeLoadTimeoutMs')}ms.`,
+                );
+                iframe.src = new URL(actionUrl, window.location.href).href;
+            } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                resolveOnce({ ok: false, reason: `Could not load hidden StoryEditContent page: ${message}` });
+            }
+        });
     },
 };

--- a/src/services/StoryReplaceService.ts
+++ b/src/services/StoryReplaceService.ts
@@ -8,8 +8,6 @@ export interface StoryReplaceResult {
     reason?: string;
 }
 
-type ReplacePhase = 'loading-page' | 'submitting-replace';
-
 function appendHiddenInput(form: HTMLFormElement, name: string, value: string): HTMLInputElement {
     const input = form.ownerDocument.createElement('input');
     input.type = 'hidden';
@@ -17,16 +15,6 @@ function appendHiddenInput(form: HTMLFormElement, name: string, value: string): 
     input.value = value;
     form.appendChild(input);
     return input;
-}
-
-function setControlValue(control: Element | null, value: string): boolean {
-    if (control && 'value' in control) {
-        const valueControl = control as HTMLInputElement | HTMLSelectElement | RadioNodeList;
-        valueControl.value = value;
-        return valueControl.value === value;
-    }
-
-    return false;
 }
 
 function normalizeText(value: string): string {
@@ -55,7 +43,7 @@ export const StoryReplaceService = {
         }
 
         return new Promise<StoryReplaceResult>((resolve) => {
-            log(`Loading hidden StoryEditContent page for chapter ${storyTextId} and doc ${docId}.`, actionUrl);
+            log(`Posting isolated replace form for chapter ${storyTextId} and doc ${docId}.`, actionUrl);
             const iframe = document.createElement('iframe');
             iframe.name = `ffne_story_replace_${Date.now()}_${Math.random().toString(36).slice(2)}`;
             iframe.style.position = 'absolute';
@@ -67,12 +55,13 @@ export const StoryReplaceService = {
             iframe.style.visibility = 'hidden';
 
             let settled = false;
-            let phase: ReplacePhase = 'loading-page';
             let timeoutId: number | null = null;
+            const form = document.createElement('form');
 
             const cleanup = () => {
                 if (timeoutId !== null) window.clearTimeout(timeoutId);
                 iframe.removeEventListener('load', onLoad);
+                form.remove();
                 iframe.remove();
             };
 
@@ -92,92 +81,60 @@ export const StoryReplaceService = {
                 }, ms);
             };
 
-            const submitNativeReplaceForm = (doc: Document): StoryReplaceResult | null => {
-                const form = StoryEditContentDelegate.getElement(Elements.STORY_EDIT_REPLACE_FORM, doc) as HTMLFormElement | null;
-                if (!form) {
-                    log('Native replace form missing from hidden StoryEditContent page.');
-                    return { ok: false, reason: 'Hidden StoryEditContent page did not contain the native replace form.' };
-                }
-
-                const chapterSelect = StoryEditContentDelegate.getElement(Elements.STORY_EDIT_CHAPTER_SELECT, doc);
-                const docSelect = StoryEditContentDelegate.getElement(Elements.STORY_EDIT_DOC_SELECT, doc);
-                const actionControl = StoryEditContentDelegate.getElement(Elements.STORY_EDIT_REPLACE_ACTION_CONTROL, doc);
-                const didSetChapter = setControlValue(chapterSelect, storyTextId);
-                const didSetDoc = setControlValue(docSelect, docId);
-                if (!setControlValue(actionControl, 'replace')) {
-                    appendHiddenInput(form, 'action', 'replace');
-                }
-
-                if (!didSetChapter) {
-                    log('Hidden replace form did not accept selected chapter.', storyTextId);
-                    return { ok: false, reason: 'Hidden replace form did not include the selected chapter.' };
-                }
-                if (!didSetDoc) {
-                    log('Hidden replace form did not accept selected source doc.', docId);
-                    return { ok: false, reason: 'Hidden replace form did not include the selected source document.' };
-                }
-
-                phase = 'submitting-replace';
-                armTimeout(
-                    SettingsManager.get('iframeSaveTimeoutMs'),
-                    `No replace response returned within ${SettingsManager.get('iframeSaveTimeoutMs')}ms.`,
-                );
-
-                log('Submitting native replace form inside hidden StoryEditContent page.');
-                form.submit();
-                return null;
-            };
-
             const onLoad = () => {
                 try {
                     const doc = iframe.contentDocument;
                     if (!doc) {
-                        log('Hidden StoryEditContent iframe had no readable document.');
-                        resolveOnce({ ok: false, reason: 'Hidden StoryEditContent frame was not readable.' });
+                        log('Hidden replace iframe had no readable document.');
+                        resolveOnce({ ok: false, reason: 'Hidden replace response frame was not readable.' });
                         return;
                     }
 
                     const frameHref = iframe.contentWindow?.location.href || '';
-                    if (phase === 'loading-page') {
-                        if (!frameHref || frameHref === 'about:blank') return;
+                    const responseText = normalizeText(doc.body?.textContent || '');
+                    if ((!frameHref || frameHref === 'about:blank') && !responseText) return;
 
-                        log('Hidden StoryEditContent page loaded; preparing native replace form.', frameHref);
-                        const submitFailure = submitNativeReplaceForm(doc);
-                        if (submitFailure) resolveOnce(submitFailure);
+                    const failureReason = getExplicitFailureReason(doc);
+                    if (failureReason) {
+                        log('Hidden replace response contained an explicit failure.', failureReason);
+                        resolveOnce({ ok: false, reason: failureReason });
                         return;
                     }
 
-                    if (phase === 'submitting-replace') {
-                        const failureReason = getExplicitFailureReason(doc);
-                        if (failureReason) {
-                            log('Hidden replace response contained an explicit failure.', failureReason);
-                            resolveOnce({ ok: false, reason: failureReason });
-                            return;
-                        }
-
-                        log('Hidden replace response loaded without explicit failure.');
-                        resolveOnce({ ok: true });
-                    }
+                    log('Hidden replace response loaded without explicit failure.');
+                    resolveOnce({ ok: true });
                 } catch (err) {
                     const message = err instanceof Error ? err.message : String(err);
-                    log('Could not inspect hidden StoryEditContent frame.', message);
-                    resolveOnce({ ok: false, reason: `Could not inspect hidden StoryEditContent frame: ${message}` });
+                    log('Could not inspect hidden replace response frame.', message);
+                    resolveOnce({ ok: false, reason: `Could not inspect hidden replace response frame: ${message}` });
                 }
             };
 
             iframe.addEventListener('load', onLoad);
-            document.body.appendChild(iframe);
 
             try {
+                form.method = 'post';
+                form.action = new URL(actionUrl, window.location.href).href;
+                form.target = iframe.name;
+                form.style.display = 'none';
+                appendHiddenInput(form, 'storytextid', storyTextId);
+                appendHiddenInput(form, 'docid', docId);
+                appendHiddenInput(form, 'action', 'replace');
+
+                document.body.append(iframe, form);
                 armTimeout(
-                    SettingsManager.get('iframeLoadTimeoutMs'),
-                    `Hidden StoryEditContent page did not load within ${SettingsManager.get('iframeLoadTimeoutMs')}ms.`,
+                    SettingsManager.get('iframeSaveTimeoutMs'),
+                    `No replace response returned within ${SettingsManager.get('iframeSaveTimeoutMs')}ms.`,
                 );
-                iframe.src = new URL(actionUrl, window.location.href).href;
+                log('Submitting isolated replace form to hidden iframe target.', {
+                    action: form.action,
+                    target: form.target,
+                });
+                form.submit();
             } catch (err) {
                 const message = err instanceof Error ? err.message : String(err);
-                log('Could not load hidden StoryEditContent page.', message);
-                resolveOnce({ ok: false, reason: `Could not load hidden StoryEditContent page: ${message}` });
+                log('Could not submit hidden replace form.', message);
+                resolveOnce({ ok: false, reason: `Could not submit hidden replace form: ${message}` });
             }
         });
     },

--- a/src/utils/runBulkOperation.ts
+++ b/src/utils/runBulkOperation.ts
@@ -1,0 +1,87 @@
+import { IBulkOperationConfig } from '../interfaces/IBulkOperationConfig';
+import { Core } from '../modules/Core';
+import { SettingsManager } from '../modules/SettingsManager';
+
+export async function runBulkOperation<TItem>(e: MouseEvent, config: IBulkOperationConfig<TItem>): Promise<void> {
+    const log = Core.getLogger('bulk-runner', 'runBulkOperation');
+    const { verb, processItem, onItemStart, onItemSuccess, onPermanentFailure, preBatch, onFinalize } = config;
+
+    log(`${verb} initiated.`);
+    const btn = e.currentTarget as HTMLButtonElement | null;
+
+    let items = config.getItems();
+    if (config.filterRows) {
+        items = config.filterRows(items);
+    }
+
+    if (items.length === 0) {
+        log(`No items to ${verb.toLowerCase()}.`);
+        return;
+    }
+
+    if (preBatch) preBatch(items.length);
+
+    const originalText = btn?.innerText || '';
+    if (btn) {
+        btn.disabled = true;
+        btn.style.cursor = 'wait';
+        btn.style.opacity = '1';
+    }
+
+    let successCount = 0;
+    const retriedItems: TItem[] = [];
+
+    try {
+        for (let i = 0; i < items.length; i++) {
+            const item = items[i];
+            if (btn) btn.innerText = `${i + 1}/${items.length}`;
+            if (onItemStart) onItemStart(item, 1, i + 1, items.length);
+
+            await new Promise(r => setTimeout(r, SettingsManager.get('bulkExportDelayMs')));
+
+            if (await processItem(item)) {
+                successCount++;
+                if (onItemSuccess) onItemSuccess(item, 1);
+            } else {
+                retriedItems.push(item);
+            }
+        }
+
+        if (retriedItems.length > 0) {
+            log(`Pass 1 done. ${retriedItems.length} items failed. Cooling...`);
+            if (btn) btn.innerText = 'Cooling...';
+            await new Promise(r => setTimeout(r, SettingsManager.get('bulkCooldownMs')));
+
+            for (let i = 0; i < retriedItems.length; i++) {
+                const item = retriedItems[i];
+                if (btn) btn.innerText = `Retry ${i + 1}/${retriedItems.length}`;
+                if (onItemStart) onItemStart(item, 2, i + 1, retriedItems.length);
+
+                await new Promise(r => setTimeout(r, SettingsManager.get('bulkRetryDelayMs')));
+
+                if (await processItem(item)) {
+                    successCount++;
+                    if (onItemSuccess) onItemSuccess(item, 2);
+                } else {
+                    if (onPermanentFailure) onPermanentFailure(item);
+                }
+            }
+        }
+
+        if (onFinalize) {
+            await onFinalize({ successCount, totalCount: items.length, retriedItems });
+        }
+    } catch (error) {
+        log(`Error during bulk ${verb}.`, error);
+        if (btn) btn.innerText = 'Error';
+    } finally {
+        if (btn) {
+            setTimeout(() => {
+                btn.innerText = originalText;
+                btn.disabled = false;
+                btn.style.cursor = 'pointer';
+                btn.style.opacity = '0.6';
+            }, 3000);
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces major enhancements to support a new "Bulk Replace" feature for the story edit content page, along with improvements to settings management and code modularity. The changes include new interfaces, delegates, and settings for the feature, as well as refactoring for better code reuse and extensibility.

**Bulk Replace Feature & Story Edit Content Support:**

- Added a new `StoryEditContentDelegate` and corresponding `Elements` enum values to enable robust querying and manipulation of the story edit content page, supporting chapter replacement and error handling. [[1]](diffhunk://#diff-19d7d39273c5f3618bba58751bb6fc76fc7bf09169dba76342983bd7533069cdR1-R123) [[2]](diffhunk://#diff-3d26e71bae538126b7fdc0111b400c976c31f93d6ae957a85c8b7a7bd1f95380R108-R135)
- Introduced new interfaces in `IStoryEditContent.ts` for representing chapters, documents, mapping rows, and operation plans, providing a strong type foundation for bulk replace logic.
- Registered the new `StoryEditContent` module and routed `/story/story_edit_content.php` to it in the application entry point, enabling initialization of the bulk replace feature on the correct page. [[1]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR12) [[2]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR87-R93)
- Updated the core module to use the new delegate strategy for the story edit content route, ensuring correct element handling and logging. [[1]](diffhunk://#diff-1b21ea137bb7efda3e2b20603b9587e7a6614886109b24d7a38c3d905d4f3e39R9) [[2]](diffhunk://#diff-1b21ea137bb7efda3e2b20603b9587e7a6614886109b24d7a38c3d905d4f3e39R86-R89) [[3]](diffhunk://#diff-1b21ea137bb7efda3e2b20603b9587e7a6614886109b24d7a38c3d905d4f3e39L153)

**Bulk Operation Infrastructure Improvements:**

- Generalized the `IBulkOperationConfig` interface to support generic item types and added an `IBulkOperationResult` interface, making bulk operations extensible and reusable across modules.
- Refactored the document manager's bulk operation logic to use a new shared `runBulkOperation` utility, reducing code duplication and improving maintainability. [[1]](diffhunk://#diff-3e64dc7a4ea7b6a7e0b487394c2a67a9420e1e5f950e007069774ce79fefaaf6R16) [[2]](diffhunk://#diff-3e64dc7a4ea7b6a7e0b487394c2a67a9420e1e5f950e007069774ce79fefaaf6L291-R299)

**Settings Management and UI:**

- Added a new `bulkReplaceAutofill` setting (default: true) to control automatic mapping of source documents in bulk replace, with corresponding UI toggle in the settings modal and test coverage. [[1]](diffhunk://#diff-670a7931b04418828223ff224c3d45e045a97a7acb773851f1ff95d254496d00R66-R71) [[2]](diffhunk://#diff-670a7931b04418828223ff224c3d45e045a97a7acb773851f1ff95d254496d00R134) [[3]](diffhunk://#diff-670a7931b04418828223ff224c3d45e045a97a7acb773851f1ff95d254496d00R316) [[4]](diffhunk://#diff-8247d31e6f4bef79ca03014fdb9e892a29e9eae73a9fc2eebcd9ab06906bac1fR25) [[5]](diffhunk://#diff-8247d31e6f4bef79ca03014fdb9e892a29e9eae73a9fc2eebcd9ab06906bac1fR224-R232) [[6]](diffhunk://#diff-97e23e1a1c407456c6abedea325de2fa78a8aabb06626e55dd9635894de25ab2R127) [[7]](diffhunk://#diff-672fa85bc1d1f28feb629ec96d4006e78463214365496b712b8c31f41f335ffaR1-R26)

**Service Enhancements:**

- Added a method to `DocFetchService` to validate that a private source document exists and contains content, improving reliability for bulk operations involving document content.

These changes lay the groundwork for advanced bulk chapter replacement workflows, improve code structure, and enhance user configurability.