### PR TITLE
Fix/403 bulk replace

### DIFF
--- a/src/__tests__/StoryEditContent.test.ts
+++ b/src/__tests__/StoryEditContent.test.ts
@@ -388,7 +388,7 @@ describe('StoryEditContent bulk replace execution', () => {
         expect(status.textContent).toContain('Replaced all 1 chapter');
     });
 
-    it('renders a failure table for failed replacements', async () => {
+    it('renders a failure table and retry button for failed replacements', async () => {
         const mappings = makeMappings(1);
         const docs = makeDocs('StoryName', 1, 1);
         StoryEditContent._setManualDocSelection(mappings, docs, 0, 'StoryName-1');
@@ -405,6 +405,7 @@ describe('StoryEditContent bulk replace execution', () => {
         expect(results.innerHTML).toContain('Chapter 1');
         expect(results.innerHTML).toContain('StoryName001');
         expect(results.innerHTML).toContain('HTTP 500');
+        expect(results.innerHTML).toContain('Retry Failed');
     });
 
     it('renders the failure table helper output', () => {
@@ -475,5 +476,144 @@ describe('StoryReplaceService hidden iframe submitter', () => {
         const promise = StoryReplaceService.submitReplaceForm('/story/story_edit_content.php?storyid=1', '101', '201');
 
         await expect(promise).resolves.toEqual({ ok: false, reason: 'No permission.' });
+    });
+
+    it('copies hidden inputs from the real FFN replace form to bypass CSRF 403', async () => {
+        document.body.innerHTML = `
+            <form action="/story/story_edit_content.php">
+                <input type="hidden" name="__csrftoken" value="abc123">
+                <input type="hidden" name="form_key" value="xyz789">
+                <input type="hidden" name="action" value="replace">
+                <input type="hidden" name="storytextid" value="">
+                <input type="hidden" name="docid" value="">
+                <select name="storytextid"><option value="0">Select</option></select>
+                <select name="docid"><option value="0">Select</option></select>
+                <input type="submit" value="Replace">
+            </form>
+        `;
+        Core.activeDelegate = StoryEditContentDelegate;
+
+        const submitSpy = vi.spyOn(HTMLFormElement.prototype, 'submit').mockImplementation(function (this: HTMLFormElement) {
+            const frame = document.querySelector(`iframe[name="${this.target}"]`) as HTMLIFrameElement;
+            expect(frame).not.toBeNull();
+            // Real-form hidden inputs should be copied
+            const csrfInput = this.elements.namedItem('__csrftoken') as HTMLInputElement;
+            expect(csrfInput).not.toBeNull();
+            expect(csrfInput.value).toBe('abc123');
+            const formKeyInput = this.elements.namedItem('form_key') as HTMLInputElement;
+            expect(formKeyInput).not.toBeNull();
+            expect(formKeyInput.value).toBe('xyz789');
+            // Our overrides should take precedence (last in form wins)
+            expect((this.elements.namedItem('storytextid') as HTMLInputElement).value).toBe('101');
+            expect((this.elements.namedItem('docid') as HTMLInputElement).value).toBe('201');
+            expect((this.elements.namedItem('action') as HTMLInputElement).value).toBe('replace');
+
+            writeFrameHtml(frame, '<div class="panel_success">Success</div>');
+            frame.dispatchEvent(new Event('load'));
+        });
+
+        const promise = StoryReplaceService.submitReplaceForm('/story/story_edit_content.php', '101', '201');
+
+        await expect(promise).resolves.toEqual({ ok: true });
+        expect(submitSpy).toHaveBeenCalledTimes(1);
+
+        Core.activeDelegate = null;
+    });
+});
+
+describe('StoryEditContent retry on failure', () => {
+    beforeEach(() => {
+        cleanupDOM();
+        vi.useFakeTimers();
+        vi.restoreAllMocks();
+        vi.stubGlobal('fetch', vi.fn());
+    });
+
+    afterEach(() => {
+        StoryEditContent._state = null;
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+        cleanupDOM();
+    });
+
+    it('renders a Retry Failed button when onRetry is provided', () => {
+        const container = document.createElement('div');
+        let retryClicked = false;
+
+        StoryEditContent._renderFailureTable(container, [{
+            chapterLabel: 'Chapter 3',
+            docName: 'StoryName003',
+            reason: 'Replace request failed with HTTP 500.',
+        }], () => { retryClicked = true; });
+
+        expect(container.innerHTML).toContain('Retry Failed');
+        const retryBtn = container.querySelector('#ffne-story-bulk-retry') as HTMLButtonElement;
+        expect(retryBtn).not.toBeNull();
+
+        retryBtn.click();
+        expect(retryClicked).toBe(true);
+    });
+
+    it('does not render a retry button when there are no failures', () => {
+        const container = document.createElement('div');
+
+        StoryEditContent._renderFailureTable(container, [], () => {});
+
+        expect(container.hidden).toBe(true);
+        expect(container.innerHTML).toBe('');
+    });
+
+    it('does not render a retry button when onRetry is not provided', () => {
+        const container = document.createElement('div');
+
+        StoryEditContent._renderFailureTable(container, [{
+            chapterLabel: 'Chapter 3',
+            docName: 'StoryName003',
+            reason: 'Failed.',
+        }]);
+
+        expect(container.innerHTML).toContain('Failed Replacements');
+        expect(container.innerHTML).not.toContain('Retry Failed');
+    });
+
+    it('retries only failed rows and preserves the original doc mapping', async () => {
+        const mappings = makeMappings(3);
+        const docs = makeDocs('StoryName', 1, 3);
+        StoryEditContent._setManualDocSelection(mappings, docs, 0, 'StoryName-1');
+        StoryEditContent._setManualDocSelection(mappings, docs, 1, 'StoryName-2');
+        StoryEditContent._setManualDocSelection(mappings, docs, 2, 'StoryName-3');
+
+        // Simulate: row 0 succeeded, row 1 and 2 failed
+        mappings[0].status = 'success';
+        mappings[1].status = 'failed';
+        mappings[2].status = 'failed';
+
+        const status = document.createElement('div');
+        const results = document.createElement('div');
+        document.body.append(status, results);
+
+        StoryEditContent._state = {
+            actionUrl: '/story/story_edit_content.php',
+            chapters: mappings.map(row => row.chapter),
+            docs,
+            mappings,
+        };
+
+        vi.spyOn(DocFetchService, 'validatePrivateDocHasContentWithResult').mockResolvedValue({ ok: true });
+        const replaceSpy = vi.spyOn(StoryReplaceService, 'submitReplaceForm').mockResolvedValue({ ok: true });
+
+        const retryPromise = StoryEditContent._retryFailedReplacements(status, results);
+        await vi.runAllTimersAsync();
+        await retryPromise;
+        await vi.runAllTimersAsync();
+
+        // Only rows 1 and 2 should have been retried
+        expect(replaceSpy).toHaveBeenCalledTimes(2);
+        expect(replaceSpy).toHaveBeenCalledWith('/story/story_edit_content.php', '1002', 'StoryName-2');
+        expect(replaceSpy).toHaveBeenCalledWith('/story/story_edit_content.php', '1003', 'StoryName-3');
+
+        // Row 0 (already successful) should not have been retried
+        const storyTextIds = replaceSpy.mock.calls.map(call => call[1]);
+        expect(storyTextIds).not.toContain('1001');
     });
 });

--- a/src/modules/StoryEditContent.ts
+++ b/src/modules/StoryEditContent.ts
@@ -448,6 +448,9 @@ export const StoryEditContent = {
         }
         log(`Opening Bulk Replace modal for ${chapters.length} chapter(s) and ${docs.length} doc(s).`);
 
+        // GOTCHA: replaceForm.action returns the <input name="action"> DOM element
+        // when such an input exists, not the action URL string. Always use
+        // getAttribute('action') to read the form's action URL.
         this._state = {
             actionUrl: replaceForm.getAttribute('action') || window.location.href,
             chapters,

--- a/src/modules/StoryEditContent.ts
+++ b/src/modules/StoryEditContent.ts
@@ -328,7 +328,11 @@ function _buildMappingPlan(mappings: IStoryEditContentMappingRow[]): IStoryEditC
     };
 }
 
-function _renderFailureTable(container: HTMLElement | null | undefined, failures: IStoryEditContentFailure[]): void {
+function _renderFailureTable(
+    container: HTMLElement | null | undefined,
+    failures: IStoryEditContentFailure[],
+    onRetry?: () => void,
+): void {
     if (!container) return;
 
     if (failures.length === 0) {
@@ -345,6 +349,10 @@ function _renderFailureTable(container: HTMLElement | null | undefined, failures
         </tr>
     `).join('');
 
+    const retryHtml = onRetry
+        ? `<div style="margin-top:8px;"><button type="button" id="ffne-story-bulk-retry" class="ffne-story-bulk-btn">Retry Failed</button></div>`
+        : '';
+
     container.hidden = false;
     container.innerHTML = `
         <div class="ffne-story-bulk-results-title">Failed Replacements</div>
@@ -358,7 +366,13 @@ function _renderFailureTable(container: HTMLElement | null | undefined, failures
             </thead>
             <tbody>${rowsHtml}</tbody>
         </table>
+        ${retryHtml}
     `;
+
+    if (onRetry) {
+        container.querySelector<HTMLButtonElement>('#ffne-story-bulk-retry')
+            ?.addEventListener('click', onRetry);
+    }
 }
 
 export const StoryEditContent = {
@@ -435,7 +449,7 @@ export const StoryEditContent = {
         log(`Opening Bulk Replace modal for ${chapters.length} chapter(s) and ${docs.length} doc(s).`);
 
         this._state = {
-            actionUrl: replaceForm.action || window.location.href,
+            actionUrl: replaceForm.getAttribute('action') || window.location.href,
             chapters,
             docs,
             mappings: _createMappingRows(chapters),
@@ -790,8 +804,13 @@ export const StoryEditContent = {
             return;
         }
 
-        const setFailure = (row: IStoryEditContentMappingRow, reason: string) => {
-            failureReasons.set(row.chapter.storyTextId, reason);
+        const setFailure = (storyTextId: string, reason: string) => {
+            failureReasons.set(storyTextId, reason);
+        };
+
+        const self = this;
+        const processRow = async function (row: IStoryEditContentMappingRow): Promise<boolean> {
+            return self._replaceChapter(row, setFailure, failureReasons);
         };
 
         const config: IBulkOperationConfig<IStoryEditContentMappingRow> = {
@@ -805,33 +824,7 @@ export const StoryEditContent = {
                     statusEl.textContent = `${action} ${index}/${total}: ${row.chapter.chapterLabel} from ${row.selectedDocName}...`;
                 }
             },
-            processItem: async (row) => {
-                row.status = 'running';
-                this._renderRowStatus(row);
-
-                const validation = await DocFetchService.validatePrivateDocHasContentWithResult(row.selectedDocId, row.selectedDocName);
-                if (!validation.ok) {
-                    log(`Source doc validation failed for "${row.selectedDocName}".`, validation.reason);
-                    setFailure(row, validation.reason || 'Source document validation failed.');
-                    return false;
-                }
-                log(`Source doc validation passed for "${row.selectedDocName}".`);
-
-                const result = await StoryReplaceService.submitReplaceForm(
-                    this._state?.actionUrl || window.location.href,
-                    row.chapter.storyTextId,
-                    row.selectedDocId,
-                );
-                if (!result.ok) {
-                    log(`Replace failed for "${row.chapter.chapterLabel}" from "${row.selectedDocName}".`, result.reason);
-                    setFailure(row, result.reason || 'FFN did not confirm the replacement.');
-                    return false;
-                }
-
-                log(`Replace succeeded for "${row.chapter.chapterLabel}" from "${row.selectedDocName}".`);
-                failureReasons.delete(row.chapter.storyTextId);
-                return true;
-            },
+            processItem: processRow,
             onItemSuccess: (row) => {
                 row.status = 'success';
                 this._renderRowStatus(row);
@@ -847,7 +840,10 @@ export const StoryEditContent = {
                 log(`Permanent replace failure for "${row.chapter.chapterLabel}".`, failures[failures.length - 1].reason);
             },
             onFinalize: ({ successCount, totalCount }) => {
-                _renderFailureTable(resultsEl, failures);
+                const retryFn = failures.length > 0
+                    ? () => { void self._retryFailedReplacements(statusEl, resultsEl); }
+                    : undefined;
+                _renderFailureTable(resultsEl, failures, retryFn);
                 log(`Bulk Replace finalized: ${successCount}/${totalCount} succeeded.`);
                 if (statusEl) {
                     if (successCount === totalCount) {
@@ -862,6 +858,122 @@ export const StoryEditContent = {
         };
 
         await runBulkOperation(e, config);
+    },
+
+    _replaceChapter: async function (
+        row: IStoryEditContentMappingRow,
+        setFailure: (storyTextId: string, reason: string) => void,
+        failureReasons: Map<string, string>,
+    ): Promise<boolean> {
+        const log = Core.getLogger(this.MODULE_NAME, '_replaceChapter');
+
+        row.status = 'running';
+        this._renderRowStatus(row);
+
+        const validation = await DocFetchService.validatePrivateDocHasContentWithResult(row.selectedDocId, row.selectedDocName);
+        if (!validation.ok) {
+            log(`Source doc validation failed for "${row.selectedDocName}".`, validation.reason);
+            setFailure(row.chapter.storyTextId, validation.reason || 'Source document validation failed.');
+            return false;
+        }
+        log(`Source doc validation passed for "${row.selectedDocName}".`);
+
+        const result = await StoryReplaceService.submitReplaceForm(
+            this._state?.actionUrl || window.location.href,
+            row.chapter.storyTextId,
+            row.selectedDocId,
+        );
+        if (!result.ok) {
+            log(`Replace failed for "${row.chapter.chapterLabel}" from "${row.selectedDocName}".`, result.reason);
+            setFailure(row.chapter.storyTextId, result.reason || 'FFN did not confirm the replacement.');
+            return false;
+        }
+
+        log(`Replace succeeded for "${row.chapter.chapterLabel}" from "${row.selectedDocName}".`);
+        failureReasons.delete(row.chapter.storyTextId);
+        return true;
+    },
+
+    _retryFailedReplacements: async function (
+        statusEl?: HTMLElement,
+        resultsEl?: HTMLElement,
+    ) {
+        if (!this._state) return;
+        const log = Core.getLogger(this.MODULE_NAME, '_retryFailedReplacements');
+
+        const failedRows = this._state.mappings.filter(row => row.status === 'failed');
+        if (failedRows.length === 0) {
+            log('Retry requested but no failed rows found.');
+            return;
+        }
+
+        log(`Retrying ${failedRows.length} failed replacement(s).`);
+        failedRows.forEach(row => {
+            row.status = 'mapped';
+            this._renderRowStatus(row);
+        });
+
+        if (statusEl) statusEl.textContent = `Retrying ${failedRows.length} failed replacement(s)...`;
+        _renderFailureTable(resultsEl, []);
+
+        const failures: IStoryEditContentFailure[] = [];
+        const failureReasons = new Map<string, string>();
+
+        const setFailure = (storyTextId: string, reason: string) => {
+            failureReasons.set(storyTextId, reason);
+        };
+
+        const self = this;
+        const processRow = async function (row: IStoryEditContentMappingRow): Promise<boolean> {
+            return self._replaceChapter(row, setFailure, failureReasons);
+        };
+
+        const retryConfig: IBulkOperationConfig<IStoryEditContentMappingRow> = {
+            verb: 'Replace',
+            getItems: () => failedRows,
+            onItemStart: (row, pass, index, total) => {
+                row.status = 'running';
+                this._renderRowStatus(row);
+                if (statusEl) {
+                    const action = pass === 2 ? 'Retrying' : 'Replacing';
+                    statusEl.textContent = `${action} ${index}/${total}: ${row.chapter.chapterLabel} from ${row.selectedDocName}...`;
+                }
+            },
+            processItem: processRow,
+            onItemSuccess: (row) => {
+                row.status = 'success';
+                this._renderRowStatus(row);
+            },
+            onPermanentFailure: (row) => {
+                row.status = 'failed';
+                this._renderRowStatus(row);
+                failures.push({
+                    chapterLabel: row.chapter.chapterLabel,
+                    docName: row.selectedDocName,
+                    reason: failureReasons.get(row.chapter.storyTextId) || 'Replace failed after retry.',
+                });
+                log(`Retry permanent failure for "${row.chapter.chapterLabel}".`, failures[failures.length - 1].reason);
+            },
+            onFinalize: ({ successCount, totalCount }) => {
+                const retryFn = failures.length > 0
+                    ? () => { void self._retryFailedReplacements(statusEl, resultsEl); }
+                    : undefined;
+                _renderFailureTable(resultsEl, failures, retryFn);
+                log(`Retry finalized: ${successCount}/${totalCount} succeeded.`);
+                if (statusEl) {
+                    if (successCount === totalCount) {
+                        statusEl.textContent = `Replaced all ${successCount} chapter(s).`;
+                    } else if (successCount > 0) {
+                        statusEl.textContent = `Replaced ${successCount}; failed ${totalCount - successCount}.`;
+                    } else {
+                        statusEl.textContent = 'No chapters were replaced.';
+                    }
+                }
+            },
+        };
+
+        const fakeEvent = { currentTarget: resultsEl?.querySelector('#ffne-story-bulk-retry') || null } as unknown as MouseEvent;
+        await runBulkOperation(fakeEvent, retryConfig);
     },
 
     _parsePublishedChapters,

--- a/src/services/StoryReplaceService.ts
+++ b/src/services/StoryReplaceService.ts
@@ -117,6 +117,16 @@ export const StoryReplaceService = {
                 form.action = new URL(actionUrl, window.location.href).href;
                 form.target = iframe.name;
                 form.style.display = 'none';
+
+                const realForm = Core.getElement(Elements.STORY_EDIT_REPLACE_FORM) as HTMLFormElement | null;
+                if (realForm) {
+                    realForm.querySelectorAll<HTMLInputElement>('input[type="hidden"]').forEach(input => {
+                        const name = (input.name || '').toLowerCase();
+                        if (name === 'storytextid' || name === 'docid' || name === 'action') return;
+                        form.appendChild(input.cloneNode(true));
+                    });
+                }
+
                 appendHiddenInput(form, 'storytextid', storyTextId);
                 appendHiddenInput(form, 'docid', docId);
                 appendHiddenInput(form, 'action', 'replace');

--- a/src/services/StoryReplaceService.ts
+++ b/src/services/StoryReplaceService.ts
@@ -118,6 +118,10 @@ export const StoryReplaceService = {
                 form.target = iframe.name;
                 form.style.display = 'none';
 
+                // GOTCHA: FFN's replace form holds CSRF tokens (e.g. __cf_bm) as
+                // hidden inputs. Building a bare form without them triggers 403
+                // from Cloudflare. Copy all hidden inputs except the ones we
+                // explicitly overwrite below.
                 const realForm = Core.getElement(Elements.STORY_EDIT_REPLACE_FORM) as HTMLFormElement | null;
                 if (realForm) {
                     realForm.querySelectorAll<HTMLInputElement>('input[type="hidden"]').forEach(input => {


### PR DESCRIPTION
This pull request enhances the bulk chapter replacement workflow in `StoryEditContent` by improving error handling, adding a user-friendly retry mechanism for failed replacements, and fixing a CSRF-related bug in the form submission process. It also updates the test suite to cover these new behaviors and edge cases.

**Bulk Replace Retry Mechanism:**

- Added a "Retry Failed" button to the failure table, allowing users to retry only the chapters that failed during the bulk replacement process. The retry logic preserves the original document mapping and updates the UI accordingly. (`src/modules/StoryEditContent.ts`, `src/__tests__/StoryEditContent.test.ts`) [[1]](diffhunk://#diff-bde34271cadccf3776b9048605dd62f9c1e44b9dc97dfdee47ade58cdf56689bR352-R355) [[2]](diffhunk://#diff-bde34271cadccf3776b9048605dd62f9c1e44b9dc97dfdee47ade58cdf56689bR369-R375) [[3]](diffhunk://#diff-bde34271cadccf3776b9048605dd62f9c1e44b9dc97dfdee47ade58cdf56689bL827-R945) [[4]](diffhunk://#diff-bde34271cadccf3776b9048605dd62f9c1e44b9dc97dfdee47ade58cdf56689bL847-R965) [[5]](diffhunk://#diff-bde34271cadccf3776b9048605dd62f9c1e44b9dc97dfdee47ade58cdf56689bL864-R979) [[6]](diffhunk://#diff-b176494ee1c2a80d6e7b4050fd0ab6c943f6201181a137f91d7f7b8f3c96295dL391-R391) [[7]](diffhunk://#diff-b176494ee1c2a80d6e7b4050fd0ab6c943f6201181a137f91d7f7b8f3c96295dR408) [[8]](diffhunk://#diff-b176494ee1c2a80d6e7b4050fd0ab6c943f6201181a137f91d7f7b8f3c96295dR480-R618)

- The failure table now conditionally renders the retry button only when there are failures and a retry handler is provided. (`src/modules/StoryEditContent.ts`, `src/__tests__/StoryEditContent.test.ts`) [[1]](diffhunk://#diff-bde34271cadccf3776b9048605dd62f9c1e44b9dc97dfdee47ade58cdf56689bR352-R355) [[2]](diffhunk://#diff-bde34271cadccf3776b9048605dd62f9c1e44b9dc97dfdee47ade58cdf56689bR369-R375) [[3]](diffhunk://#diff-b176494ee1c2a80d6e7b4050fd0ab6c943f6201181a137f91d7f7b8f3c96295dR480-R618)

**Error Handling and Status Updates:**

- Improved error tracking by associating failure reasons with `storyTextId` instead of row objects, ensuring accurate status reporting and retry behavior. (`src/modules/StoryEditContent.ts`) [[1]](diffhunk://#diff-bde34271cadccf3776b9048605dd62f9c1e44b9dc97dfdee47ade58cdf56689bL793-R816) [[2]](diffhunk://#diff-bde34271cadccf3776b9048605dd62f9c1e44b9dc97dfdee47ade58cdf56689bL827-R945)

- Refactored the bulk operation configuration to handle item success, permanent failure, and finalization more robustly, updating the UI and logs for each outcome. (`src/modules/StoryEditContent.ts`) [[1]](diffhunk://#diff-bde34271cadccf3776b9048605dd62f9c1e44b9dc97dfdee47ade58cdf56689bL808-R879) [[2]](diffhunk://#diff-bde34271cadccf3776b9048605dd62f9c1e44b9dc97dfdee47ade58cdf56689bL827-R945) [[3]](diffhunk://#diff-bde34271cadccf3776b9048605dd62f9c1e44b9dc97dfdee47ade58cdf56689bL847-R965)

**CSRF Protection and Form Submission:**

- Fixed a bug where CSRF tokens and other hidden inputs from the real FFN replace form were not copied to the dynamically created form, which previously resulted in 403 errors from Cloudflare. Now, all necessary hidden inputs are cloned except those explicitly overwritten. (`src/services/StoryReplaceService.ts`, `src/__tests__/StoryEditContent.test.ts`) [[1]](diffhunk://#diff-2ce82abf58e833dac215b4f4fe09dcd0aaf9958aa31bfcd469ca648755ee7677R120-R133) [[2]](diffhunk://#diff-b176494ee1c2a80d6e7b4050fd0ab6c943f6201181a137f91d7f7b8f3c96295dR480-R618)

**Other Improvements:**

- Ensured the action URL for the form is always read via `getAttribute('action')` to avoid DOM API pitfalls when an `<input name="action">` exists. (`src/modules/StoryEditContent.ts`)

**Test Coverage:**

- Added comprehensive tests for the retry button, retry logic, and CSRF input copying, ensuring all new behaviors are verified. (`src/__tests__/StoryEditContent.test.ts`)

These changes collectively make the bulk replacement process more robust, user-friendly, and resilient to network or CSRF-related failures.