### PR TITLE
feat: polish HTML paragraph normalization transform

### DIFF
--- a/src/__tests__/DocManager.test.ts
+++ b/src/__tests__/DocManager.test.ts
@@ -565,6 +565,7 @@ describe('DocManager bulk import execution', () => {
         Core.activeDelegate = DocManagerDelegate;
         vi.restoreAllMocks();
         vi.spyOn(SettingsManager, 'get').mockImplementation((key: any) => {
+            if (key === 'normalizeHtmlParagraphs') return true;
             if (key === 'bulkExportDelayMs' || key === 'bulkCooldownMs' || key === 'bulkRetryDelayMs') return 0;
             return 0;
         });
@@ -976,6 +977,7 @@ describe('DocManager AO3 migration execution', () => {
         vi.spyOn(DocFetchService, 'fetchPrivateDocAsHtml').mockResolvedValue("<center><p style='text-align: centre;'>Centered</p></center>");
         vi.spyOn(SettingsManager, 'get').mockImplementation((key: any) => {
             if (key === 'ao3HtmlCompatibility' || key === 'appendSeparator') return false;
+            if (key === 'normalizeHtmlParagraphs') return true;
             if (key === 'bulkExportDelayMs' || key === 'bulkCooldownMs' || key === 'bulkRetryDelayMs') return 0;
             return 0;
         });
@@ -994,6 +996,7 @@ describe('DocManager AO3 migration execution', () => {
         vi.spyOn(DocFetchService, 'fetchPrivateDocAsHtml').mockResolvedValue('<p>Line 1\nLine 2</p>');
         vi.spyOn(SettingsManager, 'get').mockImplementation((key: any) => {
             if (key === 'ao3HtmlCompatibility' || key === 'appendSeparator') return false;
+            if (key === 'normalizeHtmlParagraphs') return true;
             if (key === 'bulkExportDelayMs' || key === 'bulkCooldownMs' || key === 'bulkRetryDelayMs') return 0;
             return 0;
         });
@@ -1007,7 +1010,7 @@ describe('DocManager AO3 migration execution', () => {
         await runAo3MigrationWithPlan(withoutLinebreaks);
         await runAo3MigrationWithPlan(withLinebreaks);
 
-        expect(updateSpy.mock.calls[0][1]).toBe('<p>Line 1\nLine 2</p>');
+        expect(updateSpy.mock.calls[0][1]).toBe('<p>Line 1 Line 2</p>');
         expect(updateSpy.mock.calls[1][1]).toBe('<p>Line 1<br>Line 2</p>');
     });
 
@@ -1023,6 +1026,7 @@ describe('DocManager AO3 migration execution', () => {
         vi.spyOn(DocFetchService, 'fetchPrivateDocAsHtml').mockResolvedValue('<p>Body</p><p align="center"><strong>Notes:</strong></p><p>Remove this</p>');
         vi.spyOn(SettingsManager, 'get').mockImplementation((key: any) => {
             if (key === 'ao3HtmlCompatibility' || key === 'appendSeparator') return false;
+            if (key === 'normalizeHtmlParagraphs') return true;
             if (key === 'bulkExportDelayMs' || key === 'bulkCooldownMs' || key === 'bulkRetryDelayMs') return 0;
             return 0;
         });
@@ -1045,6 +1049,7 @@ describe('DocManager AO3 migration execution', () => {
         vi.spyOn(DocFetchService, 'fetchPrivateDocAsHtml').mockResolvedValue('<p>Body</p>Notes:\n<p>Keep this</p>');
         vi.spyOn(SettingsManager, 'get').mockImplementation((key: any) => {
             if (key === 'ao3HtmlCompatibility' || key === 'appendSeparator') return false;
+            if (key === 'normalizeHtmlParagraphs') return true;
             if (key === 'bulkExportDelayMs' || key === 'bulkCooldownMs' || key === 'bulkRetryDelayMs') return 0;
             return 0;
         });

--- a/src/__tests__/SettingsManager.test.ts
+++ b/src/__tests__/SettingsManager.test.ts
@@ -123,6 +123,7 @@ describe('_parseStoredValue — edge cases', () => {
             'pasteConvertHtml',
             'pasteForceIntercept',
             'ao3HtmlCompatibility',
+            'normalizeHtmlParagraphs',
             'appendSeparator',
             'bulkReplaceAutofill',
         ];

--- a/src/__tests__/SettingsPage.test.ts
+++ b/src/__tests__/SettingsPage.test.ts
@@ -23,4 +23,15 @@ describe('SettingsPage', () => {
         expect(toggle?.type).toBe('checkbox');
         expect(toggle?.checked).toBe(true);
     });
+
+    it('shows the HTML paragraph normalization toggle enabled by default', () => {
+        SettingsPage.openModal();
+
+        const toggle = document.querySelector<HTMLInputElement>('[data-setting="normalizeHtmlParagraphs"]');
+
+        expect(document.body.textContent).toContain('Normalize HTML Paragraph Lines');
+        expect(toggle).not.toBeNull();
+        expect(toggle?.type).toBe('checkbox');
+        expect(toggle?.checked).toBe(true);
+    });
 });

--- a/src/__tests__/exportTransform.test.ts
+++ b/src/__tests__/exportTransform.test.ts
@@ -3,6 +3,7 @@ import {
     applyExportTransforms,
     convertStyleAlignToAttr,
     appendFormatSeparator,
+    normalizeHtmlParagraphLines,
     stripContentAfterMarker,
 } from '../utils/exportTransform';
 import { DocDownloadFormat } from '../enums/DocDownloadFormat';
@@ -175,6 +176,7 @@ describe('stripContentAfterMarker', () => {
         vi.spyOn(SettingsManager, 'get').mockImplementation((key: any) => {
             if (key === 'appendSeparator') return true;
             if (key === 'ao3HtmlCompatibility') return false;
+            if (key === 'normalizeHtmlParagraphs') return true;
             return 0;
         });
 
@@ -188,5 +190,90 @@ describe('stripContentAfterMarker', () => {
         );
 
         expect(result).toBe('<p>Body</p>\n<hr>\n<p>&nbsp;</p>');
+    });
+});
+
+describe('normalizeHtmlParagraphLines', () => {
+    it('flattens multiline prose paragraphs into single lines', () => {
+        const input = '<p>First line\n    second line\nthird line</p>';
+
+        expect(normalizeHtmlParagraphLines(input)).toBe('<p>First line second line third line</p>');
+    });
+
+    it('preserves nested inline tags while flattening whitespace', () => {
+        const input = '<p>First\n    <em>second</em>\n    <strong>third</strong></p>';
+
+        expect(normalizeHtmlParagraphLines(input)).toBe('<p>First <em>second</em> <strong>third</strong></p>');
+    });
+
+    it('preserves paragraph attributes', () => {
+        const input = '<p class="intro" align="center">First\n    second</p>';
+
+        expect(normalizeHtmlParagraphLines(input)).toBe('<p class="intro" align="center">First second</p>');
+    });
+
+    it('separates adjacent paragraphs with a blank line', () => {
+        const input = '<p>First\n    paragraph.</p>\n<p><em>Second\n        paragraph.</em></p>';
+
+        expect(normalizeHtmlParagraphLines(input)).toBe(
+            '<p>First paragraph.</p>\n\n<p><em>Second paragraph.</em></p>',
+        );
+    });
+});
+
+describe('applyExportTransforms', () => {
+    it('normalizes HTML paragraphs by default', () => {
+        vi.spyOn(SettingsManager, 'get').mockImplementation((key: any) => {
+            if (key === 'ao3HtmlCompatibility' || key === 'appendSeparator') return false;
+            if (key === 'normalizeHtmlParagraphs') return true;
+            return 0;
+        });
+
+        const result = applyExportTransforms(
+            '<p>First line\n    second line</p><p>Third\n    line</p>',
+            DocDownloadFormat.HTML,
+        );
+
+        expect(result).toBe('<p>First line second line</p>\n\n<p>Third line</p>');
+    });
+
+    it('does not normalize paragraphs when the HTML setting is disabled', () => {
+        vi.spyOn(SettingsManager, 'get').mockImplementation((key: any) => {
+            if (key === 'ao3HtmlCompatibility' || key === 'appendSeparator') return false;
+            if (key === 'normalizeHtmlParagraphs') return false;
+            return 0;
+        });
+
+        const input = '<p>First line\n    second line</p><p>Third\n    line</p>';
+
+        expect(applyExportTransforms(input, DocDownloadFormat.HTML)).toBe(input);
+    });
+
+    it('leaves Markdown content unchanged', () => {
+        vi.spyOn(SettingsManager, 'get').mockImplementation((key: any) => {
+            if (key === 'ao3HtmlCompatibility' || key === 'appendSeparator') return false;
+            if (key === 'normalizeHtmlParagraphs') return true;
+            return 0;
+        });
+
+        const input = '<p>First line\n    second line</p>';
+
+        expect(applyExportTransforms(input, DocDownloadFormat.MARKDOWN)).toBe(input);
+    });
+
+    it('keeps explicit line breaks as br before paragraph normalization runs', () => {
+        vi.spyOn(SettingsManager, 'get').mockImplementation((key: any) => {
+            if (key === 'ao3HtmlCompatibility' || key === 'appendSeparator') return false;
+            if (key === 'normalizeHtmlParagraphs') return true;
+            return 0;
+        });
+
+        const result = applyExportTransforms(
+            '<p>Line 1\nLine 2</p><p>Line 3\nLine 4</p>',
+            DocDownloadFormat.HTML,
+            { convertLineBreaks: true },
+        );
+
+        expect(result).toBe('<p>Line 1<br>Line 2</p>\n\n<p>Line 3<br>Line 4</p>');
     });
 });

--- a/src/modules/SettingsManager.ts
+++ b/src/modules/SettingsManager.ts
@@ -58,6 +58,12 @@ export interface FFNSettings {
     ao3HtmlCompatibility: boolean;
 
     /**
+     * When true (default), flattens multi-line text inside exported HTML paragraph
+     * tags to single lines and inserts a blank line between adjacent paragraphs.
+     */
+    normalizeHtmlParagraphs: boolean;
+
+    /**
      * When true, appends a format-specific separator at the end of exported
      * content: `---` for Markdown, `HR tag` for HTML/DOCX.
      */
@@ -130,6 +136,7 @@ const DEFAULTS: FFNSettings = {
     pasteConvertHtml: true,
     pasteForceIntercept: false,
     ao3HtmlCompatibility: true,
+    normalizeHtmlParagraphs: true,
     appendSeparator: false,
     bulkReplaceAutofill: true,
     scrollStep: 300,
@@ -312,6 +319,7 @@ function _loadAll(): void {
     _loadBool('pasteConvertHtml');
     _loadBool('pasteForceIntercept');
     _loadBool('ao3HtmlCompatibility');
+    _loadBool('normalizeHtmlParagraphs');
     _loadBool('appendSeparator');
     _loadBool('bulkReplaceAutofill');
     _loadPositiveNumber('scrollStep');
@@ -453,4 +461,3 @@ function _notifySubscribers<K extends keyof FFNSettings>(
         }
     });
 }
-

--- a/src/modules/SettingsPage.ts
+++ b/src/modules/SettingsPage.ts
@@ -21,6 +21,7 @@ const BOOL_KEYS: (keyof FFNSettings)[] = [
     'pasteConvertHtml',
     'pasteForceIntercept',
     'ao3HtmlCompatibility',
+    'normalizeHtmlParagraphs',
     'appendSeparator',
     'bulkReplaceAutofill',
 ];
@@ -181,6 +182,12 @@ function _buildModalHTML(): string {
                         'AO3 HTML Compatibility',
                         'Converts inline style="text-align:*" to align="*" in HTML exports. AO3\'s editor only accepts the align attribute.',
                         s.get('ao3HtmlCompatibility')
+                    ),
+                    _buildToggleRow(
+                        'normalizeHtmlParagraphs',
+                        'Normalize HTML Paragraph Lines',
+                        'Flattens multi-line paragraph text in HTML exports into single lines and inserts a blank line between adjacent paragraphs.',
+                        s.get('normalizeHtmlParagraphs')
                     ),
                     _buildToggleRow(
                         'appendSeparator',

--- a/src/utils/exportTransform.ts
+++ b/src/utils/exportTransform.ts
@@ -121,6 +121,24 @@ export function convertTextLineBreaksToBr(html: string): string {
     return result;
 }
 
+export function normalizeHtmlParagraphLines(html: string): string {
+    return html
+        .replace(/<p\b[^>]*>[\s\S]*?<\/p>/gi, (paragraph: string) => {
+            const openTagMatch = paragraph.match(/^<p\b[^>]*>/i);
+            const closeTagMatch = paragraph.match(/<\/p>$/i);
+            if (!openTagMatch || !closeTagMatch) return paragraph;
+
+            const openTag = openTagMatch[0];
+            const closeTag = closeTagMatch[0];
+            const innerHtml = paragraph.slice(openTag.length, -closeTag.length)
+                .replace(/\s*[\r\n]+\s*/g, ' ')
+                .trim();
+
+            return `${openTag}${innerHtml}${closeTag}`;
+        })
+        .replace(/<\/p>\s*(<p\b[^>]*>)/gi, '</p>\n\n$1');
+}
+
 interface StripMarkerResult {
     content: string;
     stripped: boolean;
@@ -217,7 +235,9 @@ export interface ExportTransformOptions {
  *
  * 1. Ao3 HTML compatibility (only if format is HTML and setting is enabled).
  *    Not applied for DOCX — DocxBuilder reads `style` for its own alignment logic.
- * 2. Append end separator (if setting enabled, all formats).
+ * 2. Optional literal line-break conversion for HTML.
+ * 3. Optional HTML paragraph line normalization for HTML.
+ * 4. Append end separator (if setting enabled, all formats).
  */
 export function applyExportTransforms(
     content: string,
@@ -243,6 +263,10 @@ export function applyExportTransforms(
         } else {
             result = convertTextLineBreaksToBr(result);
         }
+    }
+
+    if (format === DocDownloadFormat.HTML && SettingsManager.get('normalizeHtmlParagraphs')) {
+        result = normalizeHtmlParagraphLines(result);
     }
 
     if (SettingsManager.get('appendSeparator')) {


### PR DESCRIPTION
This pull request introduces a new export setting, "Normalize HTML Paragraph Lines," which flattens multi-line text inside exported HTML paragraphs into single lines and inserts blank lines between adjacent paragraphs (for parity with Markdown paths). The setting is enabled by default, and the codebase, tests, and settings UI are updated to support and test this feature.

**Export logic and utility function updates:**

* Added the `normalizeHtmlParagraphLines` function to flatten multi-line HTML paragraph text and updated `applyExportTransforms` to use it when the new setting is enabled. This ensures exported HTML is cleaner and more consistent. [[1]](diffhunk://#diff-59c425625820cc6f5b0cb2a8437675e25627b3f6c733e263be83ccaf71c7f2a0R124-R141) [[2]](diffhunk://#diff-59c425625820cc6f5b0cb2a8437675e25627b3f6c733e263be83ccaf71c7f2a0R268-R271)

**Settings infrastructure and UI:**

* Added the `normalizeHtmlParagraphs` boolean to the `FFNSettings` interface, set its default to `true`, and included it in the settings load and modal UI, making it user-configurable. [[1]](diffhunk://#diff-670a7931b04418828223ff224c3d45e045a97a7acb773851f1ff95d254496d00R60-R65) [[2]](diffhunk://#diff-670a7931b04418828223ff224c3d45e045a97a7acb773851f1ff95d254496d00R139) [[3]](diffhunk://#diff-670a7931b04418828223ff224c3d45e045a97a7acb773851f1ff95d254496d00R322) [[4]](diffhunk://#diff-8247d31e6f4bef79ca03014fdb9e892a29e9eae73a9fc2eebcd9ab06906bac1fR24) [[5]](diffhunk://#diff-8247d31e6f4bef79ca03014fdb9e892a29e9eae73a9fc2eebcd9ab06906bac1fR186-R191)

**Test coverage:**

* Added and updated tests in `exportTransform.test.ts`, `DocManager.test.ts`, and `SettingsPage.test.ts` to verify the normalization logic, default state, and interaction with other export settings. [[1]](diffhunk://#diff-90db16e447536214ab6b8bde956ecc320b4cea0530268e30ffbaed2d03b38158R6) [[2]](diffhunk://#diff-90db16e447536214ab6b8bde956ecc320b4cea0530268e30ffbaed2d03b38158R195-R279) [[3]](diffhunk://#diff-8b99c627e2875769a9a40f8c438c770998ac93a87e0fce1e3de6da669bf48b0eR568) [[4]](diffhunk://#diff-8b99c627e2875769a9a40f8c438c770998ac93a87e0fce1e3de6da669bf48b0eR980) [[5]](diffhunk://#diff-8b99c627e2875769a9a40f8c438c770998ac93a87e0fce1e3de6da669bf48b0eR999) [[6]](diffhunk://#diff-8b99c627e2875769a9a40f8c438c770998ac93a87e0fce1e3de6da669bf48b0eL1010-R1013) [[7]](diffhunk://#diff-8b99c627e2875769a9a40f8c438c770998ac93a87e0fce1e3de6da669bf48b0eR1029) [[8]](diffhunk://#diff-8b99c627e2875769a9a40f8c438c770998ac93a87e0fce1e3de6da669bf48b0eR1052) [[9]](diffhunk://#diff-672fa85bc1d1f28feb629ec96d4006e78463214365496b712b8c31f41f335ffaR26-R36)

**Settings parsing and edge cases:**

* Updated the settings manager and related tests to recognize and handle the new `normalizeHtmlParagraphs` setting, ensuring robust storage and retrieval.

**Documentation and code comments:**

* Added clear comments and documentation for the new setting and its behavior in both settings and export transform modules. [[1]](diffhunk://#diff-670a7931b04418828223ff224c3d45e045a97a7acb773851f1ff95d254496d00R60-R65) [[2]](diffhunk://#diff-59c425625820cc6f5b0cb2a8437675e25627b3f6c733e263be83ccaf71c7f2a0L220-R240)